### PR TITLE
chore: add `set_compiled_artifacts` to ProjectCompileOutput impl

### DIFF
--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -260,6 +260,15 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
         &self.compiled_artifacts
     }
 
+    /// Sets the compiled artifacts for this output.
+    /// 
+    /// # Arguments
+    ///
+    /// * `new_compiled_artifacts` - A collection of artifacts that will replace the current compiled artifacts.
+    pub fn set_compiled_artifacts(&mut self, new_compiled_artifacts: Artifacts<T::Artifact>) {
+        self.compiled_artifacts = new_compiled_artifacts;
+    }
+
     /// Returns a `BTreeMap` that maps the compiler version used during
     /// [`crate::Project::compile()`] to a Vector of tuples containing the contract name and the
     /// `Contract`

--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -261,10 +261,6 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
     }
 
     /// Sets the compiled artifacts for this output.
-    /// 
-    /// # Arguments
-    ///
-    /// * `new_compiled_artifacts` - A collection of artifacts that will replace the current compiled artifacts.
     pub fn set_compiled_artifacts(&mut self, new_compiled_artifacts: Artifacts<T::Artifact>) {
         self.compiled_artifacts = new_compiled_artifacts;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


This pull request proposes a change to the `ProjectCompileOutput` impl by creating a method `set_compiled_artifacts`. The modification is required for the usage of extending `foundry` to work with non-solc compilers like [`zksolc`](https://github.com/matter-labs/era-compiler-solidity/tree/main) for zkSync.

**Context:**

Currently, the `compiled_artifacts` field is marked as `pub(crate)`, making it accessible only within the same crate. This encapsulation poses a limitation when the struct is used as part of a larger build process where access to `compiled_artifacts` is needed to be modified. Providing a set method to update `compiled_artifacts` it the proposed solution. 

**Rationale:**

In effort to extend `foundry` support to zkSync ecosystem, the ability to set the modified Artifact is needed. You can see where we make use of `set_compiled_artifacts` [here](https://github.com/matter-labs/foundry-zksync/blob/9820a1205ef2c4e2acfd2138c93797bafa3c6129/crates/common/src/zk_compile.rs#L352).

- **Enhanced Flexibility:** Providing `set_compiled_artifacts` allows for more flexible post-compilation processes, including custom artifact handling, storage, and modifications tailored to specific use cases.

**Functionality Impact:**

The proposed change will have no impact on existing functionality. It merely extends the accessibility of the `compiled_artifacts` field, enabling external crates to utilize the compiled bytecode. This change is backward-compatible and does not alter the behavior of any existing code that depends on the `ProjectCompileOutput` struct.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

**Solution:**

```
pub fn set_compiled_artifacts(&mut self, new_compiled_artifacts: Artifacts<T::Artifact>) {
        self.compiled_artifacts = new_compiled_artifacts;
}
```

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
