### PR TITLE
fix: create verifiable Standard JSON for projects with external files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,15 +947,31 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
 
 // Rebases the given path to the base directory lexically.
 //
-// The returned path from this function usually starts either with a normal component (e.g., `src`)
-// or a parent directory component (i.e., `..`), which is based on the base directory. Additionally,
-// this function converts the path into a UTF-8 string and replaces all separators with forward
-// slashes (`/`).
+// For instance, given the base `/home/user/project` and the path `/home/user/project/src/A.sol`,
+// this function returns `src/A.sol`.
 //
-// The rebasing process is as follows:
+// This function transforms a path into a form that is relative to the base directory. The returned
+// path starts either with a normal component (e.g., `src`) or a parent directory component (i.e.,
+// `..`). It also converts the path into a UTF-8 string and replaces all separators with forward
+// slashes (`/`), if they're not.
 //
-// 1. Remove the leading components from the path that match the base components.
-// 2. Prepend `..` components to the path, equal in number to the remaining base components.
+// The rebasing process can be conceptualized as follows:
+//
+// 1. Remove the leading components from the path that match those in the base.
+// 2. Prepend `..` components to the path, matching the number of remaining components in the base.
+//
+// # Examples
+//
+// `rebase_path("/home/user/project", "/home/user/project/src/A.sol")` returns `src/A.sol`. The
+// common part, `/home/user/project`, is removed from the path.
+//
+// `rebase_path("/home/user/project", "/home/user/A.sol")` returns `../A.sol`. First, the common
+// part, `/home/user`, is removed, leaving `A.sol`. Next, as `project` remains in the base, `..` is
+// prepended to the path.
+//
+// On Windows, paths like `a\b\c` are converted to `a/b/c`.
+//
+// For more examples, see the test.
 fn rebase_path(base: impl AsRef<Path>, path: impl AsRef<Path>) -> PathBuf {
     use path_slash::PathExt;
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -12,7 +12,7 @@ use foundry_compilers::{
     info::ContractInfo,
     project_util::*,
     remappings::Remapping,
-    Artifact, CompilerInput, ConfigurableArtifacts, ExtraOutputValues, Graph, Project,
+    utils, Artifact, CompilerInput, ConfigurableArtifacts, ExtraOutputValues, Graph, Project,
     ProjectCompileOutput, ProjectPathsConfig, Solc, TestFileFilter,
 };
 use pretty_assertions::assert_eq;
@@ -1598,6 +1598,72 @@ fn can_sanitize_bytecode_hash() {
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(compiled.find_first("A").is_some());
+}
+
+// https://github.com/foundry-rs/foundry/issues/5307
+#[test]
+fn can_create_standard_json_input_with_external_file() {
+    // File structure:
+    // .
+    // ├── bad_verif
+    // │   └── src
+    // │       └── Counter.sol
+    // └── remapped
+    //     ├── Child.sol
+    //     └── Parent.sol
+
+    let dir = tempfile::tempdir().unwrap();
+    let bad_verif_dir = utils::canonicalize(dir.path()).unwrap().join("bad_verif");
+    let remapped_dir = utils::canonicalize(dir.path()).unwrap().join("remapped");
+    fs::create_dir_all(bad_verif_dir.join("src")).unwrap();
+    fs::create_dir(&remapped_dir).unwrap();
+
+    let mut bad_verif_project = Project::builder()
+        .paths(ProjectPathsConfig::dapptools(&bad_verif_dir).unwrap())
+        .build()
+        .unwrap();
+
+    bad_verif_project.paths.remappings.push(Remapping {
+        context: None,
+        name: "@remapped/".into(),
+        path: "../remapped/".into(),
+    });
+    bad_verif_project.allowed_paths.insert(remapped_dir.clone());
+
+    fs::write(remapped_dir.join("Parent.sol"), "pragma solidity >=0.8.0; import './Child.sol';")
+        .unwrap();
+    fs::write(remapped_dir.join("Child.sol"), "pragma solidity >=0.8.0;").unwrap();
+    fs::write(
+        bad_verif_dir.join("src/Counter.sol"),
+        "pragma solidity >=0.8.0; import '@remapped/Parent.sol'; contract Counter {}",
+    )
+    .unwrap();
+
+    // solc compiles using the host file system; therefore, this setup is considered valid
+    let compiled = bad_verif_project.compile().unwrap();
+    compiled.assert_success();
+
+    // can create project root based paths
+    let std_json =
+        bad_verif_project.standard_json_input(bad_verif_dir.join("src/Counter.sol")).unwrap();
+    assert_eq!(
+        std_json.sources.iter().map(|(path, _)| path.clone()).collect::<Vec<_>>(),
+        vec![
+            PathBuf::from("src/Counter.sol"),
+            PathBuf::from("../remapped/Parent.sol"),
+            PathBuf::from("../remapped/Child.sol")
+        ]
+    );
+
+    // can compile using the created json
+    let compiler_errors = Solc::default()
+        .compile(&std_json)
+        .unwrap()
+        .errors
+        .into_iter()
+        .filter_map(|e| if e.severity.is_error() { Some(e.message) } else { None })
+        .collect::<Vec<_>>();
+    assert!(compiler_errors.is_empty(), "{:?}", compiler_errors);
 }
 
 #[test]


### PR DESCRIPTION
- Resolves https://github.com/foundry-rs/foundry/issues/5307

Currently, Foundry projects containing Solidity files outside the project root directory face contract verification failures on block explorers. This issue occurs from the Standard JSON including unusable source paths for external files, represented as full absolute paths in their host file systems.

This PR addresses the issue by improving the path conversion process. For files not located under the project root directory, relative parent directory paths (`..`) are used, enabling the compiler to find the files within the json.

Steps to reproduce the issue are detailed in the linked issue above. Additionally, a test case representing that scenario has been added.

With this change, the json created in the reproduction scenario will appear as follows:

```json
{
  "language": "Solidity",
  "sources": {
    "src/Counter.sol": {
      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.13;\n\nimport \"@remapped/Parent.sol\";\n\ncontract Counter {\n    uint256 public number;\n\n    function setNumber(uint256 newNumber) public {\n        number = newNumber;\n    }\n\n    function increment() public {\n        number++;\n    }\n}\n"
    },
    "../remapped/Parent.sol": {
      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.13;\nimport \"./Child.sol\";\n"
    },
    "../remapped/Child.sol": {
      "content": "// SPDX-License-Identifier: UNLICENSED\npragma solidity ^0.8.13;\n"
    }
  },
  "settings": {
    "remappings": [
      "@remapped/=../remapped/",
      "ds-test/=lib/forge-std/lib/ds-test/src/",
      "forge-std/=lib/forge-std/src/"
    ],
    "optimizer": {
      "enabled": true,
      "runs": 200
    },
    "metadata": {
      "useLiteralContent": false,
      "bytecodeHash": "ipfs",
      "appendCBOR": true
    },
    "outputSelection": {
      "*": {
        "": [
          "ast"
        ],
        "*": [
          "abi",
          "evm.bytecode",
          "evm.deployedBytecode",
          "evm.methodIdentifiers",
          "metadata"
        ]
      }
    },
    "evmVersion": "paris",
    "libraries": {}
  }
}
```

The source path is now aligned with the project root.

I have successfully deployed and verified the contract on Etherscan using this change.

`forge create --rpc-url "wss://ethereum-holesky.publicnode.com" --verify --verifier-url "https://api-holesky.etherscan.io/api" --etherscan-api-key "..." --private-key "..." src/Counter.sol:Counter`

https://holesky.etherscan.io/address/0xe08c332706185521fc8bc2b224f67adf814b1880#code