### PR TITLE
feat: use Box<dyn> in sparse functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,13 +379,9 @@ impl<T: ArtifactOutput> Project<T> {
     /// let output = project.compile_sparse(|path: &Path| path.ends_with("Greeter.sol")).unwrap();
     /// # }
     /// ```
-    pub fn compile_sparse<F: FileFilter + 'static>(
-        &self,
-        filter: F,
-    ) -> Result<ProjectCompileOutput<T>> {
+    pub fn compile_sparse(&self, filter: Box<dyn FileFilter>) -> Result<ProjectCompileOutput<T>> {
         let sources =
             Source::read_all(self.paths.input_files().into_iter().filter(|p| filter.is_match(p)))?;
-        let filter: Box<dyn FileFilter> = Box::new(filter);
 
         #[cfg(all(feature = "svm-solc", not(target_arch = "wasm32")))]
         if self.auto_detect {

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -85,10 +85,7 @@ impl<T: ArtifactOutput> TempProject<T> {
         self.project().compile()
     }
 
-    pub fn compile_sparse<F: FileFilter + 'static>(
-        &self,
-        filter: F,
-    ) -> Result<ProjectCompileOutput<T>> {
+    pub fn compile_sparse(&self, filter: Box<dyn FileFilter>) -> Result<ProjectCompileOutput<T>> {
         self.project().compile_sparse(filter)
     }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1550,7 +1550,7 @@ fn can_compile_sparse_with_link_references() {
         )
         .unwrap();
 
-    let mut compiled = tmp.compile_sparse(TestFileFilter::default()).unwrap();
+    let mut compiled = tmp.compile_sparse(Box::<TestFileFilter>::default()).unwrap();
     compiled.assert_success();
 
     let mut output = compiled.clone().output();


### PR DESCRIPTION
To avoid boxing twice in case that an argument is already a box.