### PR TITLE
New flattening impl

### DIFF
--- a/src/artifacts/ast/mod.rs
+++ b/src/artifacts/ast/mod.rs
@@ -182,7 +182,7 @@ ast_node!(
         #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         used_events: Vec<usize>,
         #[serde(default, rename = "internalFunctionIDs")]
-        internal_function_ids: BTreeMap<usize, usize>,
+        internal_function_ids: BTreeMap<String, usize>,
     }
 );
 

--- a/src/artifacts/ast/visitor.rs
+++ b/src/artifacts/ast/visitor.rs
@@ -1,1 +1,592 @@
+use super::*;
 
+pub trait Visitor {
+    fn visit_source_unit(&mut self, _source_unit: &SourceUnit) {}
+    fn visit_import_directive(&mut self, _directive: &ImportDirective) {}
+    fn visit_pragma_directive(&mut self, _directive: &PragmaDirective) {}
+    fn visit_block(&mut self, _block: &Block) {}
+    fn visit_statement(&mut self, _statement: &Statement) {}
+    fn visit_expression(&mut self, _expression: &Expression) {}
+    fn visit_function_call(&mut self, _function_call: &FunctionCall) {}
+    fn visit_user_defined_type_name(&mut self, _type_name: &UserDefinedTypeName) {}
+    fn visit_identifier_path(&mut self, _identifier_path: &IdentifierPath) {}
+    fn visit_type_name(&mut self, _type_name: &TypeName) {}
+    fn visit_parameter_list(&mut self, _parameter_list: &ParameterList) {}
+    fn visit_function_definition(&mut self, _definition: &FunctionDefinition) {}
+    fn visit_enum_definition(&mut self, _definition: &EnumDefinition) {}
+    fn visit_error_definition(&mut self, _definition: &ErrorDefinition) {}
+    fn visit_event_definition(&mut self, _definition: &EventDefinition) {}
+    fn visit_struct_definition(&mut self, _definition: &StructDefinition) {}
+    fn visit_modifier_definition(&mut self, _definition: &ModifierDefinition) {}
+    fn visit_variable_declaration(&mut self, _declaration: &VariableDeclaration) {}
+    fn visit_overrides(&mut self, _specifier: &OverrideSpecifier) {}
+    fn visit_user_defined_value_type(&mut self, _value_type: &UserDefinedValueTypeDefinition) {}
+    fn visit_contract_definition(&mut self, _definition: &ContractDefinition) {}
+    fn visit_using_for(&mut self, _directive: &UsingForDirective) {}
+    fn visit_unary_operation(&mut self, _unary_op: &UnaryOperation) {}
+    fn visit_binary_operation(&mut self, _binary_op: &BinaryOperation) {}
+    fn visit_conditional(&mut self, _conditional: &Conditional) {}
+    fn visit_tuple_expression(&mut self, _tuple_expression: &TupleExpression) {}
+    fn visit_new_expression(&mut self, _new_expression: &NewExpression) {}
+    fn visit_assignment(&mut self, _assignment: &Assignment) {}
+    fn visit_identifier(&mut self, _identifier: &Identifier) {}
+    fn visit_index_access(&mut self, _index_access: &IndexAccess) {}
+    fn visit_index_range_access(&mut self, _index_range_access: &IndexRangeAccess) {}
+    fn visit_while_statement(&mut self, _while_statement: &WhileStatement) {}
+    fn visit_for_statement(&mut self, _for_statement: &ForStatement) {}
+    fn visit_if_statement(&mut self, _if_statement: &IfStatement) {}
+    fn visit_do_while_statement(&mut self, _do_while_statement: &DoWhileStatement) {}
+    fn visit_emit_statement(&mut self, _emit_statement: &EmitStatement) {}
+    fn visit_unchecked_block(&mut self, _unchecked_block: &UncheckedBlock) {}
+    fn visit_try_statement(&mut self, _try_statement: &TryStatement) {}
+    fn visit_revert_statement(&mut self, _revert_statement: &RevertStatement) {}
+    fn visit_member_access(&mut self, _member_access: &MemberAccess) {}
+    fn visit_mapping(&mut self, _mapping: &Mapping) {}
+    fn visit_elementary_type_name(&mut self, _elementary_type_name: &ElementaryTypeName) {}
+    fn visit_literal(&mut self, _literal: &Literal) {}
+    fn visit_function_type_name(&mut self, _function_type_name: &FunctionTypeName) {}
+    fn visit_array_type_name(&mut self, _array_type_name: &ArrayTypeName) {}
+    fn visit_function_call_options(&mut self, _function_call: &FunctionCallOptions) {}
+    fn visit_return(&mut self, _return: &Return) {}
+    fn visit_inheritance_specifier(&mut self, _specifier: &InheritanceSpecifier) {}
+    fn visit_modifier_invocation(&mut self, _invocation: &ModifierInvocation) {}
+}
+
+pub trait Walk {
+    fn walk(&self, visitor: &mut dyn Visitor);
+}
+
+macro_rules! impl_walk {
+    // Implement `Walk` for a type, calling the given function.
+    ($ty:ty, | $val:ident, $visitor:ident | $e:expr) => {
+        impl Walk for $ty {
+            fn walk(&self, visitor: &mut dyn Visitor) {
+                let $val = self;
+                let $visitor = visitor;
+                $e
+            }
+        }
+    };
+    ($ty:ty, $func:ident) => {
+        impl_walk!($ty, |obj, visitor| {
+            visitor.$func(obj);
+        });
+    };
+    ($ty:ty, $func:ident, | $val:ident, $visitor:ident | $e:expr) => {
+        impl_walk!($ty, |$val, $visitor| {
+            $visitor.$func($val);
+            $e
+        });
+    };
+}
+
+impl_walk!(SourceUnit, visit_source_unit, |source_unit, visitor| {
+    for part in &source_unit.nodes {
+        match part {
+            SourceUnitPart::ContractDefinition(contract) => {
+                contract.walk(visitor);
+            }
+            SourceUnitPart::UsingForDirective(directive) => {
+                directive.walk(visitor);
+            }
+            SourceUnitPart::ErrorDefinition(error) => {
+                error.walk(visitor);
+            }
+            SourceUnitPart::StructDefinition(struct_) => {
+                struct_.walk(visitor);
+            }
+            SourceUnitPart::VariableDeclaration(declaration) => {
+                declaration.walk(visitor);
+            }
+            SourceUnitPart::FunctionDefinition(function) => {
+                function.walk(visitor);
+            }
+            SourceUnitPart::UserDefinedValueTypeDefinition(value_type) => {
+                value_type.walk(visitor);
+            }
+            SourceUnitPart::ImportDirective(directive) => {
+                directive.walk(visitor);
+            }
+            SourceUnitPart::EnumDefinition(enum_) => {
+                enum_.walk(visitor);
+            }
+            SourceUnitPart::PragmaDirective(directive) => {
+                directive.walk(visitor);
+            }
+        }
+    }
+});
+
+impl_walk!(ContractDefinition, visit_contract_definition, |contract, visitor| {
+    contract.base_contracts.iter().for_each(|base_contract| {
+        base_contract.walk(visitor);
+    });
+
+    for part in &contract.nodes {
+        match part {
+            ContractDefinitionPart::FunctionDefinition(function) => {
+                function.walk(visitor);
+            }
+            ContractDefinitionPart::ErrorDefinition(error) => {
+                error.walk(visitor);
+            }
+            ContractDefinitionPart::EventDefinition(event) => {
+                event.walk(visitor);
+            }
+            ContractDefinitionPart::StructDefinition(struct_) => {
+                struct_.walk(visitor);
+            }
+            ContractDefinitionPart::VariableDeclaration(declaration) => {
+                declaration.walk(visitor);
+            }
+            ContractDefinitionPart::ModifierDefinition(modifier) => {
+                modifier.walk(visitor);
+            }
+            ContractDefinitionPart::UserDefinedValueTypeDefinition(definition) => {
+                definition.walk(visitor);
+            }
+            ContractDefinitionPart::UsingForDirective(directive) => {
+                directive.walk(visitor);
+            }
+            ContractDefinitionPart::EnumDefinition(enum_) => {
+                enum_.walk(visitor);
+            }
+        }
+    }
+});
+
+impl_walk!(Expression, visit_expression, |expr, visitor| {
+    match expr {
+        Expression::FunctionCall(expression) => {
+            expression.walk(visitor);
+        }
+        Expression::MemberAccess(member_access) => {
+            member_access.walk(visitor);
+        }
+        Expression::IndexAccess(index_access) => {
+            index_access.walk(visitor);
+        }
+        Expression::UnaryOperation(unary_op) => {
+            unary_op.walk(visitor);
+        }
+        Expression::BinaryOperation(expression) => {
+            expression.walk(visitor);
+        }
+        Expression::Conditional(expression) => {
+            expression.walk(visitor);
+        }
+        Expression::TupleExpression(tuple) => {
+            tuple.walk(visitor);
+        }
+        Expression::NewExpression(expression) => {
+            expression.walk(visitor);
+        }
+        Expression::Assignment(expression) => {
+            expression.walk(visitor);
+        }
+        Expression::Identifier(identifier) => {
+            identifier.walk(visitor);
+        }
+        Expression::FunctionCallOptions(function_call) => {
+            function_call.walk(visitor);
+        }
+        Expression::IndexRangeAccess(range_access) => {
+            range_access.walk(visitor);
+        }
+        Expression::Literal(literal) => {
+            literal.walk(visitor);
+        }
+        Expression::ElementaryTypeNameExpression(type_name) => {
+            type_name.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(Statement, visit_statement, |statement, visitor| {
+    match statement {
+        Statement::Block(block) => {
+            block.walk(visitor);
+        }
+        Statement::WhileStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::ForStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::IfStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::DoWhileStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::EmitStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::VariableDeclarationStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::ExpressionStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::UncheckedBlock(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::TryStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::RevertStatement(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::Return(statement) => {
+            statement.walk(visitor);
+        }
+        Statement::Break(_)
+        | Statement::Continue(_)
+        | Statement::InlineAssembly(_)
+        | Statement::PlaceholderStatement(_) => {}
+    }
+});
+
+impl_walk!(FunctionDefinition, visit_function_definition, |function, visitor| {
+    function.parameters.walk(visitor);
+    function.return_parameters.walk(visitor);
+
+    if let Some(overrides) = &function.overrides {
+        overrides.walk(visitor);
+    }
+
+    if let Some(body) = &function.body {
+        body.walk(visitor);
+    }
+
+    function.modifiers.iter().for_each(|m| m.walk(visitor));
+});
+
+impl_walk!(ErrorDefinition, visit_error_definition, |error, visitor| {
+    error.parameters.walk(visitor);
+});
+
+impl_walk!(EventDefinition, visit_event_definition, |event, visitor| {
+    event.parameters.walk(visitor);
+});
+
+impl_walk!(StructDefinition, visit_struct_definition, |struct_, visitor| {
+    struct_.members.iter().for_each(|member| member.walk(visitor));
+});
+
+impl_walk!(ModifierDefinition, visit_modifier_definition, |modifier, visitor| {
+    modifier.body.walk(visitor);
+    if let Some(override_) = &modifier.overrides {
+        override_.walk(visitor);
+    }
+    modifier.parameters.walk(visitor);
+});
+
+impl_walk!(VariableDeclaration, visit_variable_declaration, |declaration, visitor| {
+    if let Some(value) = &declaration.value {
+        value.walk(visitor);
+    }
+
+    if let Some(type_name) = &declaration.type_name {
+        type_name.walk(visitor);
+    }
+});
+
+impl_walk!(OverrideSpecifier, visit_overrides, |override_, visitor| {
+    override_.overrides.iter().for_each(|type_name| {
+        type_name.walk(visitor);
+    });
+});
+
+impl_walk!(UserDefinedValueTypeDefinition, visit_user_defined_value_type, |value_type, visitor| {
+    value_type.underlying_type.walk(visitor);
+});
+
+impl_walk!(FunctionCallOptions, visit_function_call_options, |function_call, visitor| {
+    function_call.expression.walk(visitor);
+    function_call.options.iter().for_each(|option| {
+        option.walk(visitor);
+    });
+});
+
+impl_walk!(Return, visit_return, |return_, visitor| {
+    if let Some(expr) = return_.expression.as_ref() {
+        expr.walk(visitor);
+    }
+});
+
+impl_walk!(UsingForDirective, visit_using_for, |directive, visitor| {
+    if let Some(type_name) = &directive.type_name {
+        type_name.walk(visitor);
+    }
+    if let Some(library_name) = &directive.library_name {
+        library_name.walk(visitor);
+    }
+    for function in &directive.function_list {
+        function.function.walk(visitor);
+    }
+});
+
+impl_walk!(UnaryOperation, visit_unary_operation, |unary_op, visitor| {
+    unary_op.sub_expression.walk(visitor);
+});
+
+impl_walk!(BinaryOperation, visit_binary_operation, |binary_op, visitor| {
+    binary_op.lhs.walk(visitor);
+    binary_op.rhs.walk(visitor);
+});
+
+impl_walk!(Conditional, visit_conditional, |conditional, visitor| {
+    conditional.condition.walk(visitor);
+    conditional.true_expression.walk(visitor);
+    conditional.false_expression.walk(visitor);
+});
+
+impl_walk!(TupleExpression, visit_tuple_expression, |tuple_expression, visitor| {
+    tuple_expression.components.iter().filter_map(|component| component.as_ref()).for_each(
+        |component| {
+            component.walk(visitor);
+        },
+    );
+});
+
+impl_walk!(NewExpression, visit_new_expression, |new_expression, visitor| {
+    new_expression.type_name.walk(visitor);
+});
+
+impl_walk!(Assignment, visit_assignment, |assignment, visitor| {
+    assignment.lhs.walk(visitor);
+    assignment.rhs.walk(visitor);
+});
+impl_walk!(IfStatement, visit_if_statement, |if_statement, visitor| {
+    if_statement.condition.walk(visitor);
+    if_statement.true_body.walk(visitor);
+
+    if let Some(false_body) = &if_statement.false_body {
+        false_body.walk(visitor);
+    }
+});
+
+impl_walk!(IndexAccess, visit_index_access, |index_access, visitor| {
+    index_access.base_expression.walk(visitor);
+    if let Some(index_expression) = &index_access.index_expression {
+        index_expression.walk(visitor);
+    }
+});
+
+impl_walk!(IndexRangeAccess, visit_index_range_access, |index_range_access, visitor| {
+    index_range_access.base_expression.walk(visitor);
+    if let Some(start_expression) = &index_range_access.start_expression {
+        start_expression.walk(visitor);
+    }
+    if let Some(end_expression) = &index_range_access.end_expression {
+        end_expression.walk(visitor);
+    }
+});
+
+impl_walk!(WhileStatement, visit_while_statement, |while_statement, visitor| {
+    while_statement.condition.walk(visitor);
+    while_statement.body.walk(visitor);
+});
+
+impl_walk!(ForStatement, visit_for_statement, |for_statement, visitor| {
+    for_statement.body.walk(visitor);
+    if let Some(condition) = &for_statement.condition {
+        condition.walk(visitor);
+    }
+
+    if let Some(loop_expression) = &for_statement.loop_expression {
+        loop_expression.walk(visitor);
+    }
+
+    if let Some(initialization_expr) = &for_statement.initialization_expression {
+        initialization_expr.walk(visitor);
+    }
+});
+
+impl_walk!(DoWhileStatement, visit_do_while_statement, |do_while_statement, visitor| {
+    do_while_statement.block.walk(visitor);
+    do_while_statement.condition.walk(visitor);
+});
+
+impl_walk!(EmitStatement, visit_emit_statement, |emit_statement, visitor| {
+    emit_statement.event_call.walk(visitor);
+});
+
+impl_walk!(VariableDeclarationStatement, |stmt, visitor| {
+    stmt.declarations.iter().filter_map(|d| d.as_ref()).for_each(|declaration| {
+        declaration.walk(visitor);
+    });
+    if let Some(initial_value) = &stmt.initial_value {
+        initial_value.walk(visitor);
+    }
+});
+
+impl_walk!(UncheckedBlock, visit_unchecked_block, |unchecked_block, visitor| {
+    unchecked_block.statements.iter().for_each(|statement| {
+        statement.walk(visitor);
+    });
+});
+
+impl_walk!(TryStatement, visit_try_statement, |try_statement, visitor| {
+    try_statement.clauses.iter().for_each(|clause| {
+        clause.block.walk(visitor);
+
+        if let Some(parameter_list) = &clause.parameters {
+            parameter_list.walk(visitor);
+        }
+    });
+
+    try_statement.external_call.walk(visitor);
+});
+
+impl_walk!(RevertStatement, visit_revert_statement, |revert_statement, visitor| {
+    revert_statement.error_call.walk(visitor);
+});
+
+impl_walk!(MemberAccess, visit_member_access, |member_access, visitor| {
+    member_access.expression.walk(visitor);
+});
+
+impl_walk!(FunctionCall, visit_function_call, |function_call, visitor| {
+    function_call.expression.walk(visitor);
+    function_call.arguments.iter().for_each(|argument| {
+        argument.walk(visitor);
+    });
+});
+
+impl_walk!(Block, visit_block, |block, visitor| {
+    block.statements.iter().for_each(|statement| {
+        statement.walk(visitor);
+    });
+});
+
+impl_walk!(UserDefinedTypeName, visit_user_defined_type_name, |type_name, visitor| {
+    if let Some(path_node) = &type_name.path_node {
+        path_node.walk(visitor);
+    }
+});
+
+impl_walk!(TypeName, visit_type_name, |type_name, visitor| {
+    match type_name {
+        TypeName::ElementaryTypeName(type_name) => {
+            type_name.walk(visitor);
+        }
+        TypeName::UserDefinedTypeName(type_name) => {
+            type_name.walk(visitor);
+        }
+        TypeName::Mapping(mapping) => {
+            mapping.walk(visitor);
+        }
+        TypeName::ArrayTypeName(array) => {
+            array.walk(visitor);
+        }
+        TypeName::FunctionTypeName(function) => {
+            function.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(FunctionTypeName, visit_function_type_name, |function, visitor| {
+    function.parameter_types.walk(visitor);
+    function.return_parameter_types.walk(visitor);
+});
+
+impl_walk!(ParameterList, visit_parameter_list, |parameter_list, visitor| {
+    parameter_list.parameters.iter().for_each(|parameter| {
+        parameter.walk(visitor);
+    });
+});
+
+impl_walk!(Mapping, visit_mapping, |mapping, visitor| {
+    mapping.key_type.walk(visitor);
+    mapping.value_type.walk(visitor);
+});
+
+impl_walk!(ArrayTypeName, visit_array_type_name, |array, visitor| {
+    array.base_type.walk(visitor);
+    if let Some(length) = &array.length {
+        length.walk(visitor);
+    }
+});
+
+impl_walk!(InheritanceSpecifier, visit_inheritance_specifier, |specifier, visitor| {
+    specifier.base_name.walk(visitor);
+    specifier.arguments.iter().for_each(|arg| {
+        arg.walk(visitor);
+    });
+});
+
+impl_walk!(ModifierInvocation, visit_modifier_invocation, |invocation, visitor| {
+    invocation.arguments.iter().for_each(|arg| arg.walk(visitor));
+    invocation.modifier_name.walk(visitor);
+});
+
+impl_walk!(ElementaryTypeName, visit_elementary_type_name);
+impl_walk!(Literal, visit_literal);
+impl_walk!(ImportDirective, visit_import_directive);
+impl_walk!(PragmaDirective, visit_pragma_directive);
+impl_walk!(IdentifierPath, visit_identifier_path);
+impl_walk!(EnumDefinition, visit_enum_definition);
+impl_walk!(Identifier, visit_identifier);
+
+impl_walk!(UserDefinedTypeNameOrIdentifierPath, |type_name, visitor| {
+    match type_name {
+        UserDefinedTypeNameOrIdentifierPath::UserDefinedTypeName(type_name) => {
+            type_name.walk(visitor);
+        }
+        UserDefinedTypeNameOrIdentifierPath::IdentifierPath(identifier_path) => {
+            identifier_path.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(BlockOrStatement, |block_or_statement, visitor| {
+    match block_or_statement {
+        BlockOrStatement::Block(block) => {
+            block.walk(visitor);
+        }
+        BlockOrStatement::Statement(statement) => {
+            statement.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(ExpressionOrVariableDeclarationStatement, |val, visitor| {
+    match val {
+        ExpressionOrVariableDeclarationStatement::ExpressionStatement(expression) => {
+            expression.walk(visitor);
+        }
+        ExpressionOrVariableDeclarationStatement::VariableDeclarationStatement(stmt) => {
+            stmt.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(IdentifierOrIdentifierPath, |val, visitor| {
+    match val {
+        IdentifierOrIdentifierPath::Identifier(ident) => {
+            ident.walk(visitor);
+        }
+        IdentifierOrIdentifierPath::IdentifierPath(path) => {
+            path.walk(visitor);
+        }
+    }
+});
+
+impl_walk!(ExpressionStatement, |expression_statement, visitor| {
+    expression_statement.expression.walk(visitor);
+});
+
+impl_walk!(ElementaryTypeNameExpression, |type_name, visitor| {
+    type_name.type_name.walk(visitor);
+});
+
+impl_walk!(ElementaryOrRawTypeName, |type_name, visitor| {
+    match type_name {
+        ElementaryOrRawTypeName::ElementaryTypeName(type_name) => {
+            type_name.walk(visitor);
+        }
+        ElementaryOrRawTypeName::Raw(_) => {}
+    }
+});

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -1,0 +1,398 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    path::{Path, PathBuf},
+};
+
+use crate::{
+    artifacts::{
+        ast::SourceLocation,
+        visitor::{Visitor, Walk},
+        Identifier, IdentifierPath, MemberAccess, Source, SourceUnit, SourceUnitPart, Sources,
+        UserDefinedTypeName,
+    },
+    error::SolcError,
+    utils, Graph, Project, ProjectCompileOutput, ProjectPathsConfig, Result,
+};
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+struct ItemLocation {
+    path: PathBuf,
+    start: usize,
+    end: usize,
+}
+
+impl ItemLocation {
+    fn try_from_source_loc(src: &SourceLocation, path: PathBuf) -> Option<Self> {
+        if src.start.is_none() || src.length.is_none() {
+            return None;
+        }
+        let start = src.start.unwrap();
+        let end = start + src.length.unwrap();
+
+        Some(ItemLocation { path, start, end })
+    }
+}
+
+/// Visitor exploring AST and collecting all references to any declarations
+struct ReferencesCollector {
+    path: PathBuf,
+    references: HashMap<isize, HashSet<ItemLocation>>,
+}
+
+impl ReferencesCollector {
+    fn process_referenced_declaration(&mut self, id: isize, src: &SourceLocation) {
+        if let Some(loc) = ItemLocation::try_from_source_loc(src, self.path.clone()) {
+            self.references.entry(id).or_default().insert(loc);
+        }
+    }
+}
+
+impl Visitor for ReferencesCollector {
+    fn visit_identifier(&mut self, identifier: &Identifier) {
+        if let Some(id) = identifier.referenced_declaration {
+            self.process_referenced_declaration(id, &identifier.src);
+        }
+    }
+
+    fn visit_user_defined_type_name(&mut self, type_name: &UserDefinedTypeName) {
+        self.process_referenced_declaration(type_name.referenced_declaration, &type_name.src);
+    }
+
+    fn visit_member_access(&mut self, member_access: &MemberAccess) {
+        if let Some(id) = member_access.referenced_declaration {
+            self.process_referenced_declaration(id, &member_access.src);
+        }
+    }
+
+    fn visit_identifier_path(&mut self, path: &IdentifierPath) {
+        self.process_referenced_declaration(path.referenced_declaration, &path.src);
+    }
+}
+
+/// Context for flattening. Stores all sources and ASTs that are in scope of the flattening target.
+pub struct Flattener {
+    target: PathBuf,
+    sources: Sources,
+    asts: Vec<(PathBuf, SourceUnit)>,
+    // Sources in the order they should be written to the output file.
+    ordered_sources: Vec<PathBuf>,
+}
+
+impl Flattener {
+    pub fn new(project: &Project, output: &ProjectCompileOutput, target: &Path) -> Result<Self> {
+        // Performs DFS to collect all dependencies of a target
+        fn collect_deps(
+            path: &PathBuf,
+            paths: &ProjectPathsConfig,
+            graph: &Graph,
+            deps: &mut HashSet<PathBuf>,
+            ordered_deps: &mut Vec<PathBuf>,
+        ) -> Result<()> {
+            if deps.insert(path.clone()) {
+                let target_dir = path.parent().ok_or_else(|| {
+                    SolcError::msg(format!(
+                        "failed to get parent directory for \"{:?}\"",
+                        path.display()
+                    ))
+                })?;
+
+                let node_id = graph.files().get(path).ok_or_else(|| {
+                    SolcError::msg(format!("cannot resolve file at {:?}", path.display()))
+                })?;
+
+                let mut imports = graph.node(*node_id).imports().clone();
+                imports.sort_by_key(|i| i.loc().start);
+
+                for import in imports {
+                    let path = paths.resolve_import(target_dir, import.data().path())?;
+                    collect_deps(&path, paths, graph, deps, ordered_deps)?;
+                }
+                ordered_deps.push(path.clone());
+            }
+            Ok(())
+        }
+
+        let graph = Graph::resolve(&project.paths)?;
+
+        let mut ordered_deps = Vec::new();
+        collect_deps(
+            &target.into(),
+            &project.paths,
+            &graph,
+            &mut HashSet::new(),
+            &mut ordered_deps,
+        )?;
+
+        let sources = Source::read_all(&ordered_deps)?;
+
+        // Convert all ASTs from artifacts to strongly typed ASTs
+        let mut asts: Vec<(PathBuf, SourceUnit)> = Vec::new();
+        for (path, ast) in output.artifacts_with_files().filter_map(|(path, _, artifact)| {
+            if let Some(ast) = artifact.ast.as_ref() {
+                if sources.contains_key(&PathBuf::from(path)) {
+                    Some((path, ast))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }) {
+            asts.push((PathBuf::from(path), serde_json::from_str(&serde_json::to_string(ast)?)?));
+        }
+
+        Ok(Flattener { target: target.into(), sources, asts, ordered_sources: ordered_deps })
+    }
+
+    pub fn flatten(&self) -> String {
+        let declarations = self.collect_top_level_declarations();
+        let references = self.collect_references();
+
+        // path -> (start, end, new_value)[]
+        let mut updates = HashMap::new();
+
+        // Goes over all known declarations and collects all references to later replace them with
+        // full name of declaration.
+        //
+        // If we find more than 1 declaration with the same name, it's name is getting changed.
+        // Two Counter contracts will be renamed to Counter_0 and Counter_1
+        for (name, ids) in declarations {
+            let mut declaration_name = name.to_string();
+            let needs_rename = ids.len() > 1;
+
+            let mut ids = ids.clone().into_iter().collect::<Vec<_>>();
+            // `loc.path` is expected to be different for each id because there can't be 2 top-level
+            //
+            // Declarations with the same name sort by loc.path to make the renaming
+            // process deterministic
+            ids.sort_by(|(_, loc_0), (_, loc_1)| loc_0.path.cmp(&loc_1.path));
+
+            for (i, (id, loc)) in ids.iter().enumerate() {
+                if needs_rename {
+                    declaration_name = format!("{}_{}", name, i);
+                }
+                updates.entry(loc.path.clone()).or_insert_with(Vec::new).push((
+                    loc.start,
+                    loc.end,
+                    declaration_name.clone(),
+                ));
+                if let Some(references) = references.get(&(*id as isize)) {
+                    for loc in references {
+                        updates.entry(loc.path.clone()).or_insert_with(Vec::new).push((
+                            loc.start,
+                            loc.end,
+                            declaration_name.clone(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Replace all imports with empty strings
+        for loc in self.collect_imports() {
+            updates.entry(loc.path.clone()).or_insert_with(Vec::new).push((
+                loc.start,
+                loc.end,
+                "".to_string(),
+            ));
+        }
+
+        let pragmas = self.collect_pragmas();
+
+        // Pragmas that will be used in the resulted file
+        let mut target_pragmas = Vec::new();
+
+        for loc in &pragmas {
+            if loc.path == self.target {
+                target_pragmas.push(loc);
+            }
+            updates.entry(loc.path.clone()).or_insert_with(Vec::new).push((
+                loc.start,
+                loc.end,
+                "".to_string(),
+            ));
+        }
+
+        target_pragmas.sort_by_key(|loc| loc.start);
+        let target_pragmas =
+            target_pragmas.iter().map(|loc| self.read_location(loc)).collect::<Vec<_>>();
+
+        let mut target_license = None;
+
+        for loc in &self.collect_licenses() {
+            if loc.path == self.target {
+                target_license = Some(self.read_location(loc));
+            }
+            updates.entry(loc.path.clone()).or_insert_with(Vec::new).push((
+                loc.start,
+                loc.end,
+                "".to_string(),
+            ));
+        }
+
+        let mut result = String::new();
+
+        if let Some(target_license) = target_license {
+            result.push_str(&target_license);
+            result.push_str("\n");
+        }
+        for pragma in target_pragmas {
+            result.push_str(&pragma);
+            result.push_str("\n");
+        }
+
+        let mut resulted_sources = HashMap::new();
+
+        for (path, source) in &self.sources {
+            let mut content = source.content.as_bytes().to_vec();
+            let mut offset: isize = 0;
+            if let Some(updates) = updates.get_mut(path) {
+                updates.sort_by(|(start_0, _, _), (start_1, _, _)| start_0.cmp(start_1));
+                for update in updates {
+                    let start = (update.0 as isize + offset) as usize;
+                    let end = (update.1 as isize + offset) as usize;
+                    let new_value = &update.2;
+
+                    content.splice(start..end, new_value.bytes());
+                    offset += new_value.len() as isize - (end - start) as isize;
+                }
+            }
+            resulted_sources.insert(path, content);
+        }
+
+        for path in &self.ordered_sources {
+            let content = resulted_sources.get(path).unwrap();
+            result.push_str(&String::from_utf8_lossy(content));
+            result.push_str("\n\n");
+        }
+
+        format!("{}\n", utils::RE_THREE_OR_MORE_NEWLINES.replace_all(&result, "\n\n").trim())
+    }
+
+    // Processes all ASTs and collects all top-level declarations in the form of
+    // a mapping from name to (declaration id, source location)
+    fn collect_top_level_declarations(&self) -> HashMap<&String, HashSet<(usize, ItemLocation)>> {
+        self.asts
+            .iter()
+            .flat_map(|(path, ast)| {
+                ast.nodes
+                    .iter()
+                    .filter_map(|node| match node {
+                        SourceUnitPart::ContractDefinition(contract) => {
+                            Some((&contract.name, contract.id, &contract.src))
+                        }
+                        SourceUnitPart::EnumDefinition(enum_) => {
+                            Some((&enum_.name, enum_.id, &enum_.src))
+                        }
+                        SourceUnitPart::StructDefinition(struct_) => {
+                            Some((&struct_.name, struct_.id, &struct_.src))
+                        }
+                        SourceUnitPart::FunctionDefinition(function) => {
+                            Some((&function.name, function.id, &function.src))
+                        }
+                        SourceUnitPart::VariableDeclaration(variable) => {
+                            Some((&variable.name, variable.id, &variable.src))
+                        }
+                        SourceUnitPart::UserDefinedValueTypeDefinition(value_type) => {
+                            Some((&value_type.name, value_type.id, &value_type.src))
+                        }
+                        _ => None,
+                    })
+                    .map(|(name, id, src)| {
+                        // Find location of name in source
+                        let content: &str = &self.sources.get(path).unwrap().content;
+                        let start = src.start.unwrap();
+                        let end = start + src.length.unwrap();
+
+                        let name_start = content[start..end].find(name).unwrap();
+                        let name_end = name_start + name.len();
+
+                        let loc = ItemLocation {
+                            path: path.clone(),
+                            start: start + name_start,
+                            end: start + name_end,
+                        };
+
+                        (name, (id, loc))
+                    })
+            })
+            .fold(HashMap::new(), |mut acc, (name, (id, item_location))| {
+                acc.entry(name).or_default().insert((id, item_location));
+                acc
+            })
+    }
+
+    // Collects all references to any declaration in the form of a mapping from declaration id to
+    // set of source locations it appears in
+    fn collect_references(&self) -> HashMap<isize, HashSet<ItemLocation>> {
+        self.asts
+            .iter()
+            .flat_map(|(path, ast)| {
+                let mut collector =
+                    ReferencesCollector { path: path.clone(), references: HashMap::new() };
+                ast.walk(&mut collector);
+                collector.references
+            })
+            .fold(HashMap::new(), |mut acc, (id, locs)| {
+                acc.entry(id).or_default().extend(locs);
+                acc
+            })
+    }
+
+    // Collects all imports locations
+    fn collect_imports(&self) -> HashSet<ItemLocation> {
+        self.asts
+            .iter()
+            .flat_map(|(path, ast)| {
+                ast.nodes.iter().filter_map(|node| match node {
+                    SourceUnitPart::ImportDirective(import) => {
+                        ItemLocation::try_from_source_loc(&import.src, path.clone())
+                    }
+                    _ => None,
+                })
+            })
+            .collect()
+    }
+
+    // Collects all pragma directives locations
+    fn collect_pragmas(&self) -> HashSet<ItemLocation> {
+        self.asts
+            .iter()
+            .flat_map(|(path, ast)| {
+                ast.nodes.iter().filter_map(|node| match node {
+                    SourceUnitPart::PragmaDirective(import) => {
+                        ItemLocation::try_from_source_loc(&import.src, path.clone())
+                    }
+                    _ => None,
+                })
+            })
+            .collect()
+    }
+
+    // Collects all SPDX-License-Identifier locations
+    fn collect_licenses(&self) -> HashSet<ItemLocation> {
+        self.sources
+            .iter()
+            .flat_map(|(path, source)| {
+                let mut licenses = HashSet::new();
+                if let Some(license_start) = source.content.find("SPDX-License-Identifier:") {
+                    let start =
+                        source.content[..license_start].rfind('\n').map(|i| i + 1).unwrap_or(0);
+                    let end = start
+                        + source.content[start..]
+                            .find('\n')
+                            .unwrap_or(source.content.len() - start);
+                    licenses.insert(ItemLocation { path: path.clone(), start, end });
+                }
+                licenses
+            })
+            .collect()
+    }
+
+    // Reads a value of a given location
+    fn read_location(&self, loc: &ItemLocation) -> &str {
+        let content: &str = &self.sources.get(&loc.path).unwrap().content;
+        &content[loc.start..loc.end]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ use std::collections::{BTreeMap, HashSet};
 mod artifact_output;
 pub mod buildinfo;
 pub mod cache;
+pub mod flatten;
 pub mod hh;
 pub use artifact_output::*;
 


### PR DESCRIPTION
Ref https://github.com/foundry-rs/foundry/issues/4034.

## Solution
solang-parser AST was not sufficient to rename stuff, because it doesn't collect IDs of declarations and we can't match specific identifier to the declaration. Native solc AST gives such ability, so I've implemented native solc AST visitor.

The implementation of flattening itself consits of several steps:
1. Find all sources that are needed for target (imports of any depth).
2. Expore ASTs for all sources and find all top-level declarations (contracts, events, structs, etc).
3. Find if any top-level declarations names are same
4. If any duplicates are found, figure out new names for them (e.g. 2 `OracleLike` interfaces become `OracleLike_0` and `OracleLike_1`)
5. Walk AST and find all references to top-level declarations. Replace every reference with declaration name. We should update names even for unchanged declarations to deal with aliased imports.
6. Collect and remove all import directives.
7. Collect and remove all pragmas and license identifiers.

This flattener implementation can be a full replacer of the current impl for all cases when source being flattened can be compiled via solc.
