### PR TITLE
chore: rename output to into_output

### DIFF
--- a/src/artifacts/contract.rs
+++ b/src/artifacts/contract.rs
@@ -87,7 +87,7 @@ impl ContractBytecode {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let mut output = project.compile().unwrap().output();
+    /// let mut output = project.compile().unwrap().into_output();
     /// let contract: ContractBytecode = output.remove_first("Greeter").unwrap().into();
     /// let contract = contract.unwrap();
     /// # }
@@ -309,7 +309,7 @@ impl CompactContract {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let mut output = project.compile().unwrap().output();
+    /// let mut output = project.compile().unwrap().into_output();
     /// let contract: CompactContract = output.remove_first("Greeter").unwrap().into();
     /// let contract = contract.unwrap();
     /// # }
@@ -494,7 +494,7 @@ impl<'a> CompactContractRef<'a> {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let contract = output.find_first("Greeter").unwrap();
     /// let contract = contract.unwrap();
     /// # }

--- a/src/compile/output/contracts.rs
+++ b/src/compile/output/contracts.rs
@@ -100,7 +100,7 @@ impl VersionedContracts {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let contract = output.find_first("Greeter").unwrap();
     /// # }
     /// ```
@@ -118,7 +118,7 @@ impl VersionedContracts {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let contract = output.contracts.find("src/Greeter.sol", "Greeter").unwrap();
     /// # }
     /// ```
@@ -142,7 +142,7 @@ impl VersionedContracts {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let (_, mut contracts) = project.compile().unwrap().output().split();
+    /// let (_, mut contracts) = project.compile().unwrap().into_output().split();
     /// let contract = contracts.remove_first("Greeter").unwrap();
     /// # }
     /// ```
@@ -169,7 +169,7 @@ impl VersionedContracts {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let (_, mut contracts) = project.compile().unwrap().output().split();
+    /// let (_, mut contracts) = project.compile().unwrap().into_output().split();
     /// let contract = contracts.remove("src/Greeter.sol", "Greeter").unwrap();
     /// # }
     /// ```

--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -201,16 +201,29 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
         self
     }
 
-    /// Get the (merged) solc compiler output
+    /// Returns a reference to the (merged) solc compiler output.
+    ///
+    /// # Examples
+    ///
     /// ```no_run
     /// use foundry_compilers::{artifacts::contract::Contract, Project};
     /// use std::collections::btree_map::BTreeMap;
     ///
     /// let project = Project::builder().build().unwrap();
     /// let contracts: BTreeMap<String, Contract> =
-    ///     project.compile().unwrap().output().contracts_into_iter().collect();
+    ///     project.compile().unwrap().into_output().contracts_into_iter().collect();
     /// ```
-    pub fn output(self) -> AggregatedCompilerOutput {
+    pub fn output(&self) -> &AggregatedCompilerOutput {
+        &self.compiler_output
+    }
+
+    /// Returns a mutable reference to the (merged) solc compiler output.
+    pub fn output_mut(&mut self) -> &mut AggregatedCompilerOutput {
+        &mut self.compiler_output
+    }
+
+    /// Consumes the output and returns the (merged) solc compiler output.
+    pub fn into_output(self) -> AggregatedCompilerOutput {
         self.compiler_output
     }
 
@@ -571,7 +584,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let contract = output.find_first("Greeter").unwrap();
     /// # }
     /// ```
@@ -586,7 +599,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let mut output = project.compile().unwrap().output();
+    /// let mut output = project.compile().unwrap().into_output();
     /// let contract = output.remove_first("Greeter").unwrap();
     /// # }
     /// ```
@@ -601,7 +614,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let mut output = project.compile().unwrap().output();
+    /// let mut output = project.compile().unwrap().into_output();
     /// let contract = output.remove("src/Greeter.sol", "Greeter").unwrap();
     /// # }
     /// ```
@@ -622,7 +635,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     /// # fn demo(project: Project) {
-    /// let mut output = project.compile().unwrap().output();
+    /// let mut output = project.compile().unwrap().into_output();
     /// let info = ContractInfo::new("src/Greeter.sol:Greeter");
     /// let contract = output.remove_contract(&info).unwrap();
     /// # }
@@ -682,7 +695,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let contract = output.get("src/Greeter.sol", "Greeter").unwrap();
     /// # }
     /// ```
@@ -702,7 +715,7 @@ impl AggregatedCompilerOutput {
     /// ```
     /// use foundry_compilers::Project;
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let (sources, contracts) = output.split();
     /// # }
     /// ```
@@ -731,7 +744,8 @@ impl AggregatedCompilerOutput {
     /// use foundry_compilers::Project;
     ///
     /// let project = Project::builder().build().unwrap();
-    /// let output = project.compile().unwrap().output().with_stripped_file_prefixes(project.root());
+    /// let output =
+    ///     project.compile().unwrap().into_output().with_stripped_file_prefixes(project.root());
     /// ```
     pub fn with_stripped_file_prefixes(mut self, base: impl AsRef<Path>) -> Self {
         let base = base.as_ref();

--- a/src/compile/output/sources.rs
+++ b/src/compile/output/sources.rs
@@ -84,7 +84,7 @@ impl VersionedSourceFiles {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let source_file = output.sources.find_file("src/Greeter.sol").unwrap();
     /// # }
     /// ```
@@ -121,7 +121,7 @@ impl VersionedSourceFiles {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let output = project.compile().unwrap().output();
+    /// let output = project.compile().unwrap().into_output();
     /// let source_file = output.sources.find_id(0).unwrap();
     /// # }
     /// ```
@@ -144,7 +144,7 @@ impl VersionedSourceFiles {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let (mut sources, _) = project.compile().unwrap().output().split();
+    /// let (mut sources, _) = project.compile().unwrap().into_output().split();
     /// let source_file = sources.remove_by_path("src/Greeter.sol").unwrap();
     /// # }
     /// ```
@@ -166,7 +166,7 @@ impl VersionedSourceFiles {
     /// ```
     /// use foundry_compilers::{artifacts::*, Project};
     /// # fn demo(project: Project) {
-    /// let (mut sources, _) = project.compile().unwrap().output().split();
+    /// let (mut sources, _) = project.compile().unwrap().into_output().split();
     /// let source_file = sources.remove_by_id(0).unwrap();
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1017,7 +1017,7 @@ mod tests {
             .build()
             .unwrap();
         let project = Project::builder().paths(paths).no_artifacts().ephemeral().build().unwrap();
-        let contracts = project.compile().unwrap().succeeded().output().contracts;
+        let contracts = project.compile().unwrap().succeeded().into_output().contracts;
         // Contracts A to F
         assert_eq!(contracts.contracts().count(), 3);
     }
@@ -1045,7 +1045,7 @@ mod tests {
             .no_artifacts()
             .build()
             .unwrap();
-        let contracts = project.compile().unwrap().succeeded().output().contracts;
+        let contracts = project.compile().unwrap().succeeded().into_output().contracts;
         assert_eq!(contracts.contracts().count(), 3);
     }
 
@@ -1060,7 +1060,7 @@ mod tests {
             .build()
             .unwrap();
         let project = Project::builder().no_artifacts().paths(paths).ephemeral().build().unwrap();
-        let contracts = project.compile().unwrap().succeeded().output().contracts;
+        let contracts = project.compile().unwrap().succeeded().into_output().contracts;
         assert_eq!(contracts.contracts().count(), 2);
     }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1830,7 +1830,7 @@ fn can_detect_contract_def_source_files() {
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
 
-    let mut sources = compiled.output().sources;
+    let mut sources = compiled.into_output().sources;
     let myfunc = sources.remove_by_path(myfunc.to_string_lossy()).unwrap();
     assert!(!myfunc.contains_contract_definition());
 
@@ -1884,7 +1884,7 @@ fn can_compile_sparse_with_link_references() {
     let mut compiled = tmp.compile_sparse(Box::<TestFileFilter>::default()).unwrap();
     compiled.assert_success();
 
-    let mut output = compiled.clone().output();
+    let mut output = compiled.clone().into_output();
 
     assert!(compiled.find_first("ATest").is_some());
     assert!(compiled.find_first("MyLib").is_some());


### PR DESCRIPTION
There is no way to get the output by reference