### PR TITLE
feat: use cached artifacts if solc config is almost the same

### DIFF
--- a/src/artifacts/output_selection.rs
+++ b/src/artifacts/output_selection.rs
@@ -119,6 +119,19 @@ impl OutputSelection {
     pub fn empty_file_output_select() -> FileOutputSelection {
         Default::default()
     }
+
+    /// Returns true if this output selection is a subset of the other output selection.
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        self.0.iter().all(|(file, selection)| {
+            other.0.get(file).map_or(false, |other_selection| {
+                selection.iter().all(|(contract, outputs)| {
+                    other_selection.get(contract).map_or(false, |other_outputs| {
+                        outputs.iter().all(|output| other_outputs.contains(output))
+                    })
+                })
+            })
+        })
+    }
 }
 
 // this will make sure that if the `FileOutputSelection` for a certain file is empty will be

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -776,8 +776,8 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             return true;
         }
 
-        if self.project.solc_config != entry.solc_config {
-            trace!("solc config changed");
+        if !self.project.solc_config.can_use_cached(&entry.solc_config) {
+            trace!("solc config not compatible");
             return true;
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -771,6 +771,38 @@ impl SolcConfig {
     pub fn builder() -> SolcConfigBuilder {
         SolcConfigBuilder::default()
     }
+
+    /// Returns true if artifacts compiled with given `cached` config are compatible with this
+    /// config and if compilation can be skipped.
+    ///
+    /// Ensures that all settings fields are equal except for `output_selection` which is required
+    /// to be a subset of `cached.output_selection`.
+    pub fn can_use_cached(&self, cached: &SolcConfig) -> bool {
+        let SolcConfig { settings } = self;
+        let Settings {
+            stop_after,
+            remappings,
+            optimizer,
+            model_checker,
+            metadata,
+            output_selection,
+            evm_version,
+            via_ir,
+            debug,
+            libraries,
+        } = settings;
+
+        *stop_after == cached.settings.stop_after
+            && *remappings == cached.settings.remappings
+            && *optimizer == cached.settings.optimizer
+            && *model_checker == cached.settings.model_checker
+            && *metadata == cached.settings.metadata
+            && *evm_version == cached.settings.evm_version
+            && *via_ir == cached.settings.via_ir
+            && *debug == cached.settings.debug
+            && *libraries == cached.settings.libraries
+            && output_selection.is_subset_of(&cached.settings.output_selection)
+    }
 }
 
 impl From<SolcConfig> for Settings {


### PR DESCRIPTION
If the only difference between cached vs current solc config is `outputSelection` which is a subset of the cached output selection, then it's safe to use cached artifact.

I am currently adding logic to foundry to request only abi output and it would be nice if we could use cached abi where possible.

Impl is pretty ugly, but not sure how to make it better without cloning