### PR TITLE
refactor: extra files logic

### DIFF
--- a/src/artifact_output/configurable.rs
+++ b/src/artifact_output/configurable.rs
@@ -784,7 +784,6 @@ impl ExtraOutputFiles {
     /// Write the set values as separate files
     pub fn write_extras(&self, contract: &Contract, file: &Path) -> Result<(), SolcError> {
         self.process_abi(contract.abi.as_ref(), file)?;
-        println!("METADATA IN CONTRACT {:?}", contract.metadata);
         self.process_metadata(contract.metadata.as_ref().map(|m| &m.metadata), file)?;
         self.process_ir(contract.ir.as_deref(), file)?;
         self.process_ir_optimized(contract.ir_optimized.as_deref(), file)?;

--- a/src/artifact_output/configurable.rs
+++ b/src/artifact_output/configurable.rs
@@ -10,14 +10,21 @@
 
 use crate::{
     artifacts::{
-        bytecode::{CompactBytecode, CompactDeployedBytecode}, contract::{CompactContract, CompactContractBytecode, Contract}, output_selection::{
+        bytecode::{CompactBytecode, CompactDeployedBytecode},
+        contract::{CompactContract, CompactContractBytecode, Contract},
+        output_selection::{
             BytecodeOutputSelection, ContractOutputSelection, DeployedBytecodeOutputSelection,
             EvmOutputSelection, EwasmOutputSelection,
-        }, Ast, BytecodeObject, CompactContractBytecodeCow, DevDoc, Evm, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource, LosslessMetadata, Metadata, Offsets, Settings, StorageLayout, UserDoc
-    }, sources::VersionedSourceFile, ArtifactFile, ArtifactOutput, SolcConfig, SolcError, SourceFile
+        },
+        Ast, BytecodeObject, CompactContractBytecodeCow, DevDoc, Evm, Ewasm, FunctionDebugData,
+        GasEstimates, GeneratedSource, LosslessMetadata, Metadata, Offsets, Settings,
+        StorageLayout, UserDoc,
+    },
+    sources::VersionedSourceFile,
+    ArtifactFile, ArtifactOutput, SolcConfig, SolcError, SourceFile,
 };
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::{hex};
+use alloy_primitives::hex;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
 
@@ -172,7 +179,7 @@ impl ConfigurableArtifacts {
 
     /// Returns the `Settings` this configuration corresponds to
     pub fn settings(&self) -> Settings {
-            SolcConfig::builder().additional_outputs(self.output_selection()).build().into()
+        SolcConfig::builder().additional_outputs(self.output_selection()).build().into()
     }
 
     /// Returns the output selection corresponding to this configuration
@@ -387,22 +394,36 @@ impl ArtifactOutput for ConfigurableArtifacts {
         if self.additional_files.generated_sources && !self.additional_values.generated_sources {
             return false;
         }
-        return true;
+        true
     }
 
-    fn try_write_extras_from_artifact(&self, artifact_file: &ArtifactFile<Self::Artifact>) -> Result<(), SolcError> {
+    fn try_write_extras_from_artifact(
+        &self,
+        artifact_file: &ArtifactFile<Self::Artifact>,
+    ) -> Result<(), SolcError> {
         let file = &artifact_file.file;
         let artifact = &artifact_file.artifact;
-        self.additional_files.process_abi(artifact.abi.as_ref(), &file)?;
-        self.additional_files.process_assembly(artifact.assembly.as_deref(), &file)?;
-        self.additional_files.process_bytecode(artifact.bytecode.as_ref().map(|b| &b.object), &file)?;
-        self.additional_files.process_deployed_bytecode(artifact.deployed_bytecode.as_ref().and_then(|d| d.bytecode.as_ref()).map(|b| &b.object), &file)?;
-        self.additional_files.process_generated_sources(Some(&artifact.generated_sources), &file)?;
-        self.additional_files.process_ir(artifact.ir.as_deref(), &file)?;
-        self.additional_files.process_ir_optimized(artifact.ir_optimized.as_deref(), &file)?;
-        self.additional_files.process_ewasm(artifact.ewasm.as_ref(), &file)?;
-        self.additional_files.process_metadata(artifact.metadata.as_ref(), &file)?;
-        self.additional_files.process_source_map(artifact.bytecode.as_ref().and_then(|b| b.source_map.as_deref()), &file)?;
+        self.additional_files.process_abi(artifact.abi.as_ref(), file)?;
+        self.additional_files.process_assembly(artifact.assembly.as_deref(), file)?;
+        self.additional_files
+            .process_bytecode(artifact.bytecode.as_ref().map(|b| &b.object), file)?;
+        self.additional_files.process_deployed_bytecode(
+            artifact
+                .deployed_bytecode
+                .as_ref()
+                .and_then(|d| d.bytecode.as_ref())
+                .map(|b| &b.object),
+            file,
+        )?;
+        self.additional_files.process_generated_sources(Some(&artifact.generated_sources), file)?;
+        self.additional_files.process_ir(artifact.ir.as_deref(), file)?;
+        self.additional_files.process_ir_optimized(artifact.ir_optimized.as_deref(), file)?;
+        self.additional_files.process_ewasm(artifact.ewasm.as_ref(), file)?;
+        self.additional_files.process_metadata(artifact.metadata.as_ref(), file)?;
+        self.additional_files.process_source_map(
+            artifact.bytecode.as_ref().and_then(|b| b.source_map.as_deref()),
+            file,
+        )?;
 
         Ok(())
     }
@@ -664,7 +685,11 @@ impl ExtraOutputFiles {
         Ok(())
     }
 
-    fn process_ir_optimized(&self, ir_optimized: Option<&str>, file: &Path) -> Result<(), SolcError> {
+    fn process_ir_optimized(
+        &self,
+        ir_optimized: Option<&str>,
+        file: &Path,
+    ) -> Result<(), SolcError> {
         if self.ir_optimized {
             if let Some(ir_optimized) = ir_optimized {
                 let file = file.with_extension("iropt");
@@ -695,7 +720,11 @@ impl ExtraOutputFiles {
         Ok(())
     }
 
-    fn process_generated_sources(&self, generated_sources: Option<&Vec<GeneratedSource>>, file: &Path) -> Result<(), SolcError> {
+    fn process_generated_sources(
+        &self,
+        generated_sources: Option<&Vec<GeneratedSource>>,
+        file: &Path,
+    ) -> Result<(), SolcError> {
         if self.generated_sources {
             if let Some(generated_sources) = generated_sources {
                 let file = file.with_extension("gensources");
@@ -716,7 +745,11 @@ impl ExtraOutputFiles {
         Ok(())
     }
 
-    fn process_bytecode(&self, bytecode: Option<&BytecodeObject>, file: &Path) -> Result<(), SolcError> {
+    fn process_bytecode(
+        &self,
+        bytecode: Option<&BytecodeObject>,
+        file: &Path,
+    ) -> Result<(), SolcError> {
         if self.bytecode {
             if let Some(bytecode) = bytecode {
                 let code = hex::encode(bytecode.as_ref());
@@ -727,7 +760,11 @@ impl ExtraOutputFiles {
         Ok(())
     }
 
-    fn process_deployed_bytecode(&self, deployed: Option<&BytecodeObject>, file: &Path) -> Result<(), SolcError> {
+    fn process_deployed_bytecode(
+        &self,
+        deployed: Option<&BytecodeObject>,
+        file: &Path,
+    ) -> Result<(), SolcError> {
         if self.deployed_bytecode {
             if let Some(deployed) = deployed {
                 let code = hex::encode(deployed.as_ref());
@@ -755,7 +792,10 @@ impl ExtraOutputFiles {
         let deployed_bytecode = evm.and_then(|evm| evm.deployed_bytecode.as_ref());
         self.process_source_map(bytecode.and_then(|b| b.source_map.as_deref()), file)?;
         self.process_bytecode(bytecode.map(|b| &b.object), file)?;
-        self.process_deployed_bytecode(deployed_bytecode.and_then(|d| d.bytecode.as_ref()).map(|b| &b.object), file)?;
+        self.process_deployed_bytecode(
+            deployed_bytecode.and_then(|d| d.bytecode.as_ref()).map(|b| &b.object),
+            file,
+        )?;
 
         Ok(())
     }

--- a/src/artifact_output/mod.rs
+++ b/src/artifact_output/mod.rs
@@ -2,7 +2,9 @@
 
 use crate::{
     artifacts::{
-        contract::{CompactContract, CompactContractBytecode, Contract}, BytecodeObject, CompactBytecode, CompactContractBytecodeCow, CompactDeployedBytecode, FileToContractsMap, SourceFile
+        contract::{CompactContract, CompactContractBytecode, Contract},
+        BytecodeObject, CompactBytecode, CompactContractBytecodeCow, CompactDeployedBytecode,
+        FileToContractsMap, SourceFile,
     },
     compile::output::{contracts::VersionedContracts, sources::VersionedSourceFiles},
     error::Result,
@@ -988,7 +990,10 @@ pub trait ArtifactOutput {
         false
     }
 
-    fn try_write_extras_from_artifact(&self, _artifact_file: &ArtifactFile<Self::Artifact>) -> Result<()> {
+    fn try_write_extras_from_artifact(
+        &self,
+        _artifact_file: &ArtifactFile<Self::Artifact>,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/src/artifact_output/mod.rs
+++ b/src/artifact_output/mod.rs
@@ -2,9 +2,7 @@
 
 use crate::{
     artifacts::{
-        contract::{CompactContract, CompactContractBytecode, Contract},
-        BytecodeObject, CompactBytecode, CompactContractBytecodeCow, CompactDeployedBytecode,
-        FileToContractsMap, SourceFile,
+        contract::{CompactContract, CompactContractBytecode, Contract}, BytecodeObject, CompactBytecode, CompactContractBytecodeCow, CompactDeployedBytecode, FileToContractsMap, SourceFile
     },
     compile::output::{contracts::VersionedContracts, sources::VersionedSourceFiles},
     error::Result,
@@ -985,6 +983,14 @@ pub trait ArtifactOutput {
         _path: &str,
         _file: &VersionedSourceFile,
     ) -> Option<Self::Artifact>;
+
+    fn can_write_extras_from_artifact(&self) -> bool {
+        false
+    }
+
+    fn try_write_extras_from_artifact(&self, _artifact_file: &ArtifactFile<Self::Artifact>) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Additional context to use during [`ArtifactOutput::on_output()`]

--- a/src/artifact_output/mod.rs
+++ b/src/artifact_output/mod.rs
@@ -623,41 +623,17 @@ pub trait ArtifactOutput {
         artifacts.join_all(&layout.artifacts);
         artifacts.write_all()?;
 
-        self.write_extras(contracts, &artifacts)?;
+        self.handle_artifacts(contracts, &artifacts)?;
 
         Ok(artifacts)
     }
 
-    /// Write additional files for the contract
-    fn write_contract_extras(&self, contract: &Contract, file: &Path) -> Result<()> {
-        ExtraOutputFiles::all().write_extras(contract, file)
-    }
-
-    /// Writes additional files for the contracts if the included in the `Contract`, such as `ir`,
-    /// `ewasm`, `iropt`.
-    ///
-    /// By default, these fields are _not_ enabled in the [`crate::artifacts::Settings`], see
-    /// [`crate::artifacts::output_selection::OutputSelection::default_output_selection()`], and the
-    /// respective fields of the [`Contract`] will `None`. If they'll be manually added to the
-    /// `output_selection`, then we're also creating individual files for this output, such as
-    /// `Greeter.iropt`, `Gretter.ewasm`
-    fn write_extras(
+    /// Invoked after artifacts has been written to disk for additional processing.
+    fn handle_artifacts(
         &self,
-        contracts: &VersionedContracts,
-        artifacts: &Artifacts<Self::Artifact>,
+        _contracts: &VersionedContracts,
+        _artifacts: &Artifacts<Self::Artifact>,
     ) -> Result<()> {
-        for (file, contracts) in contracts.as_ref().iter() {
-            for (name, versioned_contracts) in contracts {
-                for c in versioned_contracts {
-                    if let Some(artifact) = artifacts.find_artifact(file, name, &c.version) {
-                        let file = &artifact.file;
-                        utils::create_parent_dir_all(file)?;
-                        self.write_contract_extras(&c.contract, file)?;
-                    }
-                }
-            }
-        }
-
         Ok(())
     }
 
@@ -986,14 +962,13 @@ pub trait ArtifactOutput {
         _file: &VersionedSourceFile,
     ) -> Option<Self::Artifact>;
 
-    fn can_write_extras_from_artifact(&self) -> bool {
-        false
+    /// Handler allowing artifacts handler to enforce artifact recompilation.
+    fn is_dirty(&self, _artifact_file: &ArtifactFile<Self::Artifact>) -> Result<bool> {
+        Ok(false)
     }
 
-    fn try_write_extras_from_artifact(
-        &self,
-        _artifact_file: &ArtifactFile<Self::Artifact>,
-    ) -> Result<()> {
+    /// Invoked with all artifacts that were not recompiled.
+    fn handle_cached_artifacts(&self, _artifacts: &Artifacts<Self::Artifact>) -> Result<()> {
         Ok(())
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -809,9 +809,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         for artifacts in self.cached_artifacts.values() {
             for artifacts in artifacts.values() {
                 for artifact_file in artifacts {
-                    println!("{:?}", artifact_file.file);
                     if self.project.artifacts_handler().is_dirty(artifact_file).unwrap_or(true) {
-                        println!("HERE");
                         return true;
                     }
                 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -804,8 +804,18 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             return true;
         }
 
-        if !self.project.artifacts_handler().can_write_extras_from_artifact() {
-            return true;
+        // If any requested extra files are missing for any artifact, mark source as dirty to
+        // generate them
+        for artifacts in self.cached_artifacts.values() {
+            for artifacts in artifacts.values() {
+                for artifact_file in artifacts {
+                    println!("{:?}", artifact_file.file);
+                    if self.project.artifacts_handler().is_dirty(artifact_file).unwrap_or(true) {
+                        println!("HERE");
+                        return true;
+                    }
+                }
+            }
         }
 
         // all things match, can be reused

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -804,6 +804,10 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             return true;
         }
 
+        if !self.project.artifacts_handler().can_write_extras_from_artifact() {
+            return true
+        }
+
         // all things match, can be reused
         false
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -805,7 +805,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         }
 
         if !self.project.artifacts_handler().can_write_extras_from_artifact() {
-            return true
+            return true;
         }
 
         // all things match, can be reused

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -336,7 +336,9 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
                     for artifacts in cache.cached_artifacts.values() {
                         for artifacts in artifacts.values() {
                             for artifact_file in artifacts {
-                                project.artifacts_handler().try_write_extras_from_artifact(artifact_file)?;
+                                project
+                                    .artifacts_handler()
+                                    .try_write_extras_from_artifact(artifact_file)?;
                             }
                         }
                     }

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -329,6 +329,21 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
                 ctx,
             )?;
 
+            match cache {
+                ArtifactsCache::Cached(ref cache) => {
+                    trace!("writing extra output files for cached artifacts");
+
+                    for artifacts in cache.cached_artifacts.values() {
+                        for artifacts in artifacts.values() {
+                            for artifact_file in artifacts {
+                                project.artifacts_handler().try_write_extras_from_artifact(artifact_file)?;
+                            }
+                        }
+                    }
+                }
+                ArtifactsCache::Ephemeral(..) => {}
+            }
+
             // emits all the build infos, if they exist
             output.write_build_infos(project.build_info_path())?;
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -331,17 +331,7 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
 
             match cache {
                 ArtifactsCache::Cached(ref cache) => {
-                    trace!("writing extra output files for cached artifacts");
-
-                    for artifacts in cache.cached_artifacts.values() {
-                        for artifacts in artifacts.values() {
-                            for artifact_file in artifacts {
-                                project
-                                    .artifacts_handler()
-                                    .try_write_extras_from_artifact(artifact_file)?;
-                            }
-                        }
-                    }
+                    project.artifacts_handler().handle_cached_artifacts(&cache.cached_artifacts)?;
                 }
                 ArtifactsCache::Ephemeral(..) => {}
             }

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -686,7 +686,10 @@ fn compile_parallel(
 #[cfg(all(feature = "project-util", feature = "svm-solc"))]
 mod tests {
     use super::*;
-    use crate::{project_util::TempProject, MinimalCombinedArtifacts};
+    use crate::{
+        artifacts::output_selection::ContractOutputSelection, project_util::TempProject,
+        ConfigurableArtifacts, MinimalCombinedArtifacts,
+    };
 
     fn init_tracing() {
         let _ = tracing_subscriber::fmt()
@@ -838,5 +841,26 @@ mod tests {
         let project = Project::builder().paths(paths).build().unwrap();
         let compiler = ProjectCompiler::new(&project).unwrap();
         let _out = compiler.compile().unwrap();
+    }
+
+    #[test]
+    fn extra_output_cached() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/dapp-sample");
+        let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
+        let mut project = TempProject::<ConfigurableArtifacts>::new(paths.clone()).unwrap();
+
+        // Compile once without enabled extra output
+        project.compile().unwrap();
+
+        // Enable extra output of abi
+        project.project_mut().artifacts =
+            ConfigurableArtifacts::new([], [ContractOutputSelection::Abi]);
+
+        // Ensure that abi appears after compilation and that we didn't recompile anything
+        let abi_path = project.project().paths.artifacts.join("Dapp.sol/Dapp.abi.json");
+        assert!(!abi_path.exists());
+        let output = project.compile().unwrap();
+        assert!(output.compiler_output.is_empty());
+        assert!(abi_path.exists());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -987,6 +987,17 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
     ) -> Option<Self::Artifact> {
         self.artifacts_handler().standalone_source_file_to_artifact(path, file)
     }
+
+    fn can_write_extras_from_artifact(&self) -> bool {
+        self.artifacts_handler().can_write_extras_from_artifact()
+    }
+
+    fn try_write_extras_from_artifact(
+        &self,
+        artifact_file: &ArtifactFile<Self::Artifact>,
+    ) -> Result<()> {
+        self.artifacts_handler().try_write_extras_from_artifact(artifact_file)
+    }
 }
 
 // Rebases the given path to the base directory lexically.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,16 +904,12 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
         self.artifacts_handler().on_output(contracts, sources, layout, ctx)
     }
 
-    fn write_contract_extras(&self, contract: &Contract, file: &Path) -> Result<()> {
-        self.artifacts_handler().write_contract_extras(contract, file)
-    }
-
-    fn write_extras(
+    fn handle_artifacts(
         &self,
         contracts: &VersionedContracts,
         artifacts: &Artifacts<Self::Artifact>,
     ) -> Result<()> {
-        self.artifacts_handler().write_extras(contracts, artifacts)
+        self.artifacts_handler().handle_artifacts(contracts, artifacts)
     }
 
     fn output_file_name(name: impl AsRef<str>) -> PathBuf {
@@ -988,15 +984,12 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
         self.artifacts_handler().standalone_source_file_to_artifact(path, file)
     }
 
-    fn can_write_extras_from_artifact(&self) -> bool {
-        self.artifacts_handler().can_write_extras_from_artifact()
+    fn is_dirty(&self, artifact_file: &ArtifactFile<Self::Artifact>) -> Result<bool> {
+        self.artifacts_handler().is_dirty(artifact_file)
     }
 
-    fn try_write_extras_from_artifact(
-        &self,
-        artifact_file: &ArtifactFile<Self::Artifact>,
-    ) -> Result<()> {
-        self.artifacts_handler().try_write_extras_from_artifact(artifact_file)
+    fn handle_cached_artifacts(&self, artifacts: &Artifacts<Self::Artifact>) -> Result<()> {
+        self.artifacts_handler().handle_cached_artifacts(artifacts)
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/foundry-rs/foundry/issues/6241 

Removes `write_extra` logic from `ArtifactOutput` trait
Adds new methods:
- `handle_artifacts` - by default empty implementation which can be overloaded to implement handling of compiled artifacts. `ConfigurableArtifacts` implements it to write extra files
- `is_dirty` - method allowing `ArtifactOutput` implementations to reject cached artifacts and enforce recompilation. Used by `ConfigurableArtifacts` to reject artifacts which data is not enough to write required extra output files.
- `handle_cached_artifacts` - same as `handle_artifacts` but for those which were not recompiled. Used by `ConfigurableArtifacts` to write extra files from cached artifacts.