### PR TITLE
refactor: caching logic

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -303,33 +303,6 @@ impl SolFilesCache {
         Ok(Artifacts(artifacts))
     }
 
-    /// Retains only the `CacheEntry` specified by the file + version combination.
-    ///
-    /// In other words, only keep those cache entries with the paths (keys) that the iterator yields
-    /// and only keep the versions in the cache entry that the version iterator yields.
-    pub fn retain<'a, I, V>(&mut self, files: I)
-    where
-        I: IntoIterator<Item = (&'a Path, V)>,
-        V: IntoIterator<Item = &'a Version>,
-    {
-        let mut files: HashMap<_, _> = files.into_iter().collect();
-
-        self.files.retain(|file, entry| {
-            if entry.artifacts.is_empty() {
-                // keep entries that didn't emit any artifacts in the first place, such as a
-                // solidity file that only includes error definitions
-                return true;
-            }
-
-            if let Some(versions) = files.remove(file.as_path()) {
-                entry.retain_versions(versions);
-            } else {
-                return false;
-            }
-            !entry.artifacts.is_empty()
-        });
-    }
-
     /// Inserts the provided cache entries, if there is an existing `CacheEntry` it will be updated
     /// but versions will be merged.
     pub fn extend<I>(&mut self, entries: I)
@@ -580,6 +553,28 @@ impl CacheEntry {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct GroupedSources {
+    pub inner: HashMap<PathBuf, HashSet<Version>>,
+}
+
+impl GroupedSources {
+    pub fn insert(&mut self, file: PathBuf, version: Version) {
+        match self.inner.entry(file) {
+            hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().insert(version);
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(HashSet::from([version]));
+            }
+        }
+    }
+
+    pub fn contains(&self, file: &Path, version: &Version) -> bool {
+        self.inner.get(file).map_or(false, |versions| versions.contains(version))
+    }
+}
+
 /// A helper abstraction over the [`SolFilesCache`] used to determine what files need to compiled
 /// and which `Artifacts` can be reused.
 #[derive(Debug)]
@@ -596,18 +591,16 @@ pub(crate) struct ArtifactsCacheInner<'a, T: ArtifactOutput> {
     /// The project.
     pub project: &'a Project<T>,
 
-    /// All the files that were filtered because they haven't changed.
-    pub filtered: HashMap<PathBuf, (Source, HashSet<Version>)>,
+    /// Files that require recompilation.
+    pub dirty_sources: GroupedSources,
 
-    /// The corresponding cache entries for all sources that were deemed to be dirty.
+    /// All the files that haven't changed.
+    pub clean_sources: GroupedSources,
+
+    /// Files that appear in cache but are not in scope of the current compiler invocation.
     ///
-    /// `CacheEntry` are grouped by their Solidity file.
-    /// During preprocessing the `artifacts` field of a new `CacheEntry` is left blank, because in
-    /// order to determine the artifacts of the solidity file, the file needs to be compiled first.
-    /// Only after the `CompilerOutput` is received and all compiled contracts are handled, see
-    /// [`crate::ArtifactOutput::on_output`] all artifacts, their disk paths, are determined and
-    /// can be populated before the updated [`crate::SolFilesCache`] is finally written to disk.
-    pub dirty_source_files: HashMap<PathBuf, (CacheEntry, HashSet<Version>)>,
+    /// Those files should be kept in the cache, so we don't lose data on filtered runs.
+    pub out_of_scope_sources: GroupedSources,
 
     /// The file hashes.
     pub content_hashes: HashMap<PathBuf, String>,
@@ -638,30 +631,6 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         entry
     }
 
-    /// inserts a new cache entry for the given file
-    ///
-    /// If there is already an entry available for the file the given version is added to the set
-    fn insert_new_cache_entry(&mut self, file: &Path, source: &Source, version: Version) {
-        if let Some((_, versions)) = self.dirty_source_files.get_mut(file) {
-            versions.insert(version);
-        } else {
-            let entry = self.create_cache_entry(file, source);
-            self.dirty_source_files.insert(file.to_path_buf(), (entry, HashSet::from([version])));
-        }
-    }
-
-    /// inserts the filtered source with the given version
-    fn insert_filtered_source(&mut self, file: PathBuf, source: Source, version: Version) {
-        match self.filtered.entry(file) {
-            hash_map::Entry::Occupied(mut entry) => {
-                entry.get_mut().1.insert(version);
-            }
-            hash_map::Entry::Vacant(entry) => {
-                entry.insert((source, HashSet::from([version])));
-            }
-        }
-    }
-
     /// Returns the set of [Source]s that need to be included in the `CompilerOutput` in order to
     /// recompile the project.
     ///
@@ -687,6 +656,14 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         let mut clean_sources = Vec::with_capacity(sources.len());
         let dirty_files = self.get_dirty_files(&sources, version);
 
+        // Mark sources which appear in cache but are not in scope of the current compiler run as
+        // out of scope.
+        for source in self.cache.files.keys().cloned().collect::<Vec<_>>() {
+            if !sources.contains_key(&source) {
+                self.out_of_scope_sources.insert(source, version.clone());
+            }
+        }
+
         for (file, source) in sources {
             let source = self.filter_source(file, source, &dirty_files);
             if source.dirty {
@@ -698,9 +675,11 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             }
         }
 
-        // track new cache entries for dirty files
+        // We are adding the dirty sources to the cache before those are populated with imports of
+        // dirty files because we don't want to recompile dirty files imports but just need them to
+        // be marked as [FilteredSource::Clean] so that we apply output selection optimization.
         for (file, filtered) in dirty_sources.iter() {
-            self.insert_new_cache_entry(file, filtered.source(), version.clone());
+            self.mark_dirty(file, filtered.source(), version);
         }
 
         for clean_source in clean_sources {
@@ -709,10 +688,18 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                 // file is pulled in by a dirty file
                 dirty_sources.insert(file.clone(), FilteredSource::Clean(source.clone()));
             }
-            self.insert_filtered_source(file, source, version.clone());
+            self.clean_sources.insert(file, version.clone());
         }
 
         dirty_sources.into()
+    }
+
+    fn mark_dirty(&mut self, file: &Path, source: &Source, version: &Version) {
+        self.dirty_sources.insert(file.to_path_buf(), version.clone());
+        if !self.cache.files.contains_key(file) {
+            let entry = self.create_cache_entry(file, source);
+            self.cache.files.insert(file.to_path_buf(), entry);
+        }
     }
 
     /// Returns the state of the given source file.
@@ -762,12 +749,12 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
     fn is_dirty_impl(&self, file: &Path, version: &Version) -> bool {
         let Some(hash) = self.content_hashes.get(file) else {
-            trace!("missing cache entry");
+            trace!("missing content hash");
             return true;
         };
 
         let Some(entry) = self.cache.entry(file) else {
-            trace!("missing content hash");
+            trace!("missing cache entry");
             return true;
         };
 
@@ -892,9 +879,10 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
                 cached_artifacts,
                 edges,
                 project,
-                filtered: Default::default(),
-                dirty_source_files: Default::default(),
+                clean_sources: Default::default(),
+                dirty_sources: Default::default(),
                 content_hashes: Default::default(),
+                out_of_scope_sources: Default::default(),
             };
 
             ArtifactsCache::Cached(cache)
@@ -973,75 +961,52 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
         let ArtifactsCacheInner {
             mut cache,
             mut cached_artifacts,
-            mut dirty_source_files,
-            filtered,
+            dirty_sources,
+            out_of_scope_sources,
             project,
             ..
         } = cache;
 
-        // keep only those files that were previously filtered (not dirty, reused)
-        cache.retain(filtered.iter().map(|(p, (_, v))| (p.as_path(), v)));
+        // Remove cached artifacts which are out of scope, dirty or appear in `written_artifacts`.
+        cached_artifacts.0.retain(|file, artifacts| {
+            let file = Path::new(file);
+            artifacts.retain(|name, artifacts| {
+                artifacts.retain(|artifact| {
+                    let version = &artifact.version;
 
-        // add the written artifacts to the cache entries, this way we can keep a mapping
-        // from solidity file to its artifacts
-        // this step is necessary because the concrete artifacts are only known after solc
-        // was invoked and received as output, before that we merely know the file and
-        // the versions, so we add the artifacts on a file by file basis
-        for (file, written_artifacts) in written_artifacts.as_ref() {
-            let file_path = Path::new(file);
-            if let Some((cache_entry, versions)) = dirty_source_files.get_mut(file_path) {
-                cache_entry.insert_artifacts(written_artifacts.iter().map(|(name, artifacts)| {
-                    let artifacts = artifacts
-                        .iter()
-                        .filter(|artifact| versions.contains(&artifact.version))
-                        .collect::<Vec<_>>();
-                    (name, artifacts)
-                }));
-            }
-
-            // cached artifacts that were overwritten also need to be removed from the
-            // `cached_artifacts` set
-            if let Some((f, mut cached)) = cached_artifacts.0.remove_entry(file) {
-                trace!(file, "checking for obsolete cached artifact entries");
-                cached.retain(|name, cached_artifacts| {
-                    let Some(written_files) = written_artifacts.get(name) else {
-                        return false;
-                    };
-
-                    // written artifact clashes with a cached artifact, so we need to decide whether
-                    // to keep or to remove the cached
-                    cached_artifacts.retain(|f| {
-                        // we only keep those artifacts that don't conflict with written artifacts
-                        // and which version was a compiler target
-                        let same_version =
-                            written_files.iter().all(|other| other.version != f.version);
-                        let is_filtered = filtered
-                            .get(file_path)
-                            .map(|(_, versions)| versions.contains(&f.version))
-                            .unwrap_or_default();
-                        let retain = same_version && is_filtered;
-                        if !retain {
-                            trace!(
-                                artifact=%f.file.display(),
-                                contract=%name,
-                                version=%f.version,
-                                "purging obsolete cached artifact",
-                            );
-                        }
-                        retain
-                    });
-
-                    !cached_artifacts.is_empty()
+                    if out_of_scope_sources.contains(file, version) {
+                        false
+                    } else if dirty_sources.contains(file, version) {
+                        false
+                    } else if written_artifacts
+                        .find_artifact(&file.to_string_lossy(), name, version)
+                        .is_some()
+                    {
+                        false
+                    } else {
+                        true
+                    }
                 });
+                !artifacts.is_empty()
+            });
+            !artifacts.is_empty()
+        });
 
-                if !cached.is_empty() {
-                    cached_artifacts.0.insert(f, cached);
-                }
-            }
+        // Update cache entries for dirty sources with newly compiled artifacts.
+        for (file, artifacts) in written_artifacts.as_ref() {
+            let file_path = Path::new(file);
+
+            let Some(dirty_versions) = dirty_sources.inner.get(file_path) else { continue };
+            let Some(entry) = cache.files.get_mut(file_path) else { continue };
+
+            entry.insert_artifacts(artifacts.iter().map(|(name, artifacts)| {
+                let artifacts = artifacts
+                    .iter()
+                    .filter(|artifact| dirty_versions.contains(&artifact.version))
+                    .collect::<Vec<_>>();
+                (name, artifacts)
+            }));
         }
-
-        // add the new cache entries to the cache file
-        cache.extend(dirty_source_files.into_iter().map(|(file, (entry, _))| (file, entry)));
 
         // write to disk
         if write_to_disk {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -665,7 +665,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                 // should compile it to populate the cache.
                 let missing = self
                     .cached_artifacts
-                    .get(file.to_string_lossy().as_ref())
+                    .get(&format!("{}", file.display()))
                     .map_or(true, |artifacts| {
                         artifacts.values().flatten().all(|a| a.version != *version)
                     });

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -666,6 +666,14 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             return true;
         };
 
+        // only check artifact's existence if the file generated artifacts.
+        // e.g. a solidity file consisting only of import statements (like interfaces that
+        // re-export) do not create artifacts
+        if entry.artifacts.is_empty() {
+            trace!("no artifacts");
+            return false;
+        }
+
         if !entry.contains_version(version) {
             trace!("missing linked artifacts",);
             return true;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -975,16 +975,16 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
                     let version = &artifact.version;
 
                     if out_of_scope_sources.contains(file, version) {
-                        return false
+                        return false;
                     }
                     if dirty_sources.contains(file, version) {
-                        return false
-                    } 
+                        return false;
+                    }
                     if written_artifacts
                         .find_artifact(&file.to_string_lossy(), name, version)
                         .is_some()
                     {
-                        return false
+                        return false;
                     }
                     true
                 });

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -699,6 +699,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
     fn mark_dirty(&mut self, file: &Path, source: &Source, version: &Version) {
         self.dirty_sources.insert(file.to_path_buf(), version.clone());
+        // We always create and insert a new entry to overwrite solc settings, content hash, etc.
         let entry = self.create_cache_entry(file, source);
         self.cache.files.insert(file.to_path_buf(), entry);
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -596,10 +596,6 @@ pub(crate) struct ArtifactsCacheInner<'a, T: ArtifactOutput> {
     /// Those are not grouped by version and purged completely.
     pub dirty_sources: HashSet<PathBuf>,
 
-    /// Artifact+version pairs for which we were missing artifacts and expecting to receive them
-    /// from compilation.
-    pub missing_sources: GroupedSources,
-
     /// Artifact+version pairs which are in scope for each solc version.
     ///
     /// Only those files will be included into cached artifacts list for each version.
@@ -664,7 +660,6 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                 // If source is not dirty, but we are missing artifacts for this version, we
                 // should compile it to populate the cache.
                 compile_complete.insert(file.clone());
-                self.missing_sources.insert(file.clone(), version.clone());
             }
 
             // Ensure that we have a cache entry for all sources.
@@ -869,7 +864,6 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
                 dirty_sources: Default::default(),
                 content_hashes: Default::default(),
                 sources_in_scope: Default::default(),
-                missing_sources: Default::default(),
             };
 
             ArtifactsCache::Cached(cache)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -706,14 +706,6 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
             return true;
         };
 
-        // only check artifact's existence if the file generated artifacts.
-        // e.g. a solidity file consisting only of import statements (like interfaces that
-        // re-export) do not create artifacts
-        if entry.artifacts.is_empty() {
-            trace!("no artifacts");
-            return false;
-        }
-
         if !entry.contains_version(version) {
             trace!("missing linked artifacts",);
             return true;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -553,12 +553,14 @@ impl CacheEntry {
     }
 }
 
+/// Collection of source file paths mapped to versions.
 #[derive(Debug, Clone, Default)]
 pub struct GroupedSources {
     pub inner: HashMap<PathBuf, HashSet<Version>>,
 }
 
 impl GroupedSources {
+    /// Inserts provided source and version into the collection.
     pub fn insert(&mut self, file: PathBuf, version: Version) {
         match self.inner.entry(file) {
             hash_map::Entry::Occupied(mut entry) => {
@@ -570,6 +572,7 @@ impl GroupedSources {
         }
     }
 
+    /// Returns true if the file was included with the given version.
     pub fn contains(&self, file: &Path, version: &Version) -> bool {
         self.inner.get(file).map_or(false, |versions| versions.contains(version))
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -638,7 +638,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
     /// Returns the set of [Source]s that need to be compiled to produce artifacts for requested
     /// input.
     ///
-    /// Source file may have two [SourceCompilationKind]s:
+    /// Source file may have one of the two [SourceCompilationKind]s:
     /// 1. [SourceCompilationKind::Complete] - the file has been modified or compiled with different
     ///    settings and its cache is invalidated. For such sources we request full data needed for
     ///    artifact construction.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -975,17 +975,18 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
                     let version = &artifact.version;
 
                     if out_of_scope_sources.contains(file, version) {
-                        false
-                    } else if dirty_sources.contains(file, version) {
-                        false
-                    } else if written_artifacts
+                        return false
+                    }
+                    if dirty_sources.contains(file, version) {
+                        return false
+                    } 
+                    if written_artifacts
                         .find_artifact(&file.to_string_lossy(), name, version)
                         .is_some()
                     {
-                        false
-                    } else {
-                        true
+                        return false
                     }
+                    true
                 });
                 !artifacts.is_empty()
             });

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -699,10 +699,8 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
     fn mark_dirty(&mut self, file: &Path, source: &Source, version: &Version) {
         self.dirty_sources.insert(file.to_path_buf(), version.clone());
-        if !self.cache.files.contains_key(file) {
-            let entry = self.create_cache_entry(file, source);
-            self.cache.files.insert(file.to_path_buf(), entry);
-        }
+        let entry = self.create_cache_entry(file, source);
+        self.cache.files.insert(file.to_path_buf(), entry);
     }
 
     /// Returns the state of the given source file.

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -706,7 +706,6 @@ mod tests {
         // 3 contracts
         assert_eq!(cache.dirty_sources.inner.len(), 3);
         assert!(cache.clean_sources.inner.is_empty());
-        assert!(cache.cache.is_empty());
 
         let compiled = prep.compile().unwrap();
         assert_eq!(compiled.output.contracts.files().count(), 3);

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -436,8 +436,8 @@ impl CompilerSources {
                     let sources_to_compile = cache.filter(sources, &version);
                     trace!(
                         "Detected {} sources to compile {:?}",
-                        sources_to_compile.complete().count(),
-                        sources_to_compile.complete_files().collect::<Vec<_>>()
+                        sources_to_compile.dirty().count(),
+                        sources_to_compile.dirty_files().collect::<Vec<_>>()
                     );
                     (solc, (version, sources_to_compile))
                 })
@@ -518,7 +518,7 @@ fn compile_sequential(
             solc.args
         );
 
-        let dirty_files: Vec<PathBuf> = filtered_sources.complete_files().cloned().collect();
+        let dirty_files: Vec<PathBuf> = filtered_sources.dirty_files().cloned().collect();
 
         // depending on the composition of the filtered sources, the output selection can be
         // optimized
@@ -597,7 +597,7 @@ fn compile_parallel(
             continue;
         }
 
-        let dirty_files: Vec<PathBuf> = filtered_sources.complete_files().cloned().collect();
+        let dirty_files: Vec<PathBuf> = filtered_sources.dirty_files().cloned().collect();
 
         // depending on the composition of the filtered sources, the output selection can be
         // optimized
@@ -791,8 +791,8 @@ mod tests {
         // 3 contracts total
         assert_eq!(filtered.0.len(), 3);
         // A is modified
-        assert_eq!(filtered.complete().count(), 1);
-        assert!(filtered.complete_files().next().unwrap().ends_with("A.sol"));
+        assert_eq!(filtered.dirty().count(), 1);
+        assert!(filtered.dirty_files().next().unwrap().ends_with("A.sol"));
 
         let state = state.compile().unwrap();
         assert_eq!(state.output.sources.len(), 3);

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -329,13 +329,6 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
                 ctx,
             )?;
 
-            match cache {
-                ArtifactsCache::Cached(ref cache) => {
-                    project.artifacts_handler().handle_cached_artifacts(&cache.cached_artifacts)?;
-                }
-                ArtifactsCache::Ephemeral(..) => {}
-            }
-
             // emits all the build infos, if they exist
             output.write_build_infos(project.build_info_path())?;
 
@@ -370,6 +363,9 @@ impl<'a, T: ArtifactOutput> ArtifactsState<'a, T> {
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");
 
         let cached_artifacts = cache.consume(&compiled_artifacts, !skip_write_to_disk)?;
+
+        project.artifacts_handler().handle_cached_artifacts(&cached_artifacts)?;
+
         Ok(ProjectCompileOutput {
             compiler_output: output,
             compiled_artifacts,
@@ -708,8 +704,8 @@ mod tests {
         let prep = compiler.preprocess().unwrap();
         let cache = prep.cache.as_cached().unwrap();
         // 3 contracts
-        assert_eq!(cache.dirty_source_files.len(), 3);
-        assert!(cache.filtered.is_empty());
+        assert_eq!(cache.dirty_sources.len(), 3);
+        assert!(cache.clean_sources.is_empty());
         assert!(cache.cache.is_empty());
 
         let compiled = prep.compile().unwrap();
@@ -728,7 +724,7 @@ mod tests {
         let inner = project.project();
         let compiler = ProjectCompiler::new(inner).unwrap();
         let prep = compiler.preprocess().unwrap();
-        assert!(prep.cache.as_cached().unwrap().dirty_source_files.is_empty())
+        assert!(prep.cache.as_cached().unwrap().dirty_sources.is_empty())
     }
 
     #[test]

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -791,6 +791,7 @@ mod tests {
         // 3 contracts total
         assert_eq!(filtered.0.len(), 3);
         // A is modified
+        assert_eq!(state.cache.as_cached().unwrap().dirty_sources.len(), 1);
         assert_eq!(filtered.dirty().count(), 1);
         assert!(filtered.dirty_files().next().unwrap().ends_with("A.sol"));
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -783,6 +783,13 @@ mod tests {
         let state = compiler.preprocess().unwrap();
         let sources = state.sources.sources();
 
+        let cache = state.cache.as_cached().unwrap();
+
+        // 2 clean sources
+        assert_eq!(cache.cache.artifacts_len(), 2);
+        assert!(cache.cache.all_artifacts_exist());
+        assert_eq!(cache.dirty_sources.len(), 1);
+
         // single solc
         assert_eq!(sources.len(), 1);
 
@@ -791,7 +798,6 @@ mod tests {
         // 3 contracts total
         assert_eq!(filtered.0.len(), 3);
         // A is modified
-        assert_eq!(state.cache.as_cached().unwrap().dirty_sources.len(), 1);
         assert_eq!(filtered.dirty().count(), 1);
         assert!(filtered.dirty_files().next().unwrap().ends_with("A.sol"));
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -704,8 +704,8 @@ mod tests {
         let prep = compiler.preprocess().unwrap();
         let cache = prep.cache.as_cached().unwrap();
         // 3 contracts
-        assert_eq!(cache.dirty_sources.len(), 3);
-        assert!(cache.clean_sources.is_empty());
+        assert_eq!(cache.dirty_sources.inner.len(), 3);
+        assert!(cache.clean_sources.inner.is_empty());
         assert!(cache.cache.is_empty());
 
         let compiled = prep.compile().unwrap();
@@ -724,7 +724,7 @@ mod tests {
         let inner = project.project();
         let compiler = ProjectCompiler::new(inner).unwrap();
         let prep = compiler.preprocess().unwrap();
-        assert!(prep.cache.as_cached().unwrap().dirty_sources.is_empty())
+        assert!(prep.cache.as_cached().unwrap().dirty_sources.inner.is_empty())
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -114,7 +114,7 @@ impl SparseOutputFilter {
 
         for (file, source) in sources.0.iter() {
             let key = format!("{}", file.display());
-            if source.is_complete() && f.is_match(file) {
+            if source.is_dirty() && f.is_match(file) {
                 settings.output_selection.as_mut().insert(key, selection.clone());
 
                 // the filter might not cover link references that will be required by the file, so
@@ -201,22 +201,22 @@ impl FilteredSources {
 
     /// Returns `true` if no sources should have optimized output selection.
     pub fn all_dirty(&self) -> bool {
-        self.0.values().all(|s| s.is_complete())
+        self.0.values().all(|s| s.is_dirty())
     }
 
     /// Returns all entries that should not be optimized.
     pub fn dirty(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
-        self.0.iter().filter(|(_, s)| s.is_complete())
+        self.0.iter().filter(|(_, s)| s.is_dirty())
     }
 
     /// Returns all entries that should be optimized.
     pub fn clean(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
-        self.0.iter().filter(|(_, s)| !s.is_complete())
+        self.0.iter().filter(|(_, s)| !s.is_dirty())
     }
 
     /// Returns all files that should not be optimized.
     pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
-        self.0.iter().filter_map(|(k, s)| s.is_complete().then_some(k))
+        self.0.iter().filter_map(|(k, s)| s.is_dirty().then_some(k))
     }
 }
 
@@ -280,7 +280,7 @@ impl SourceCompilationKind {
     }
 
     /// Whether this file should be compiled with full output selection
-    pub fn is_complete(&self) -> bool {
+    pub fn is_dirty(&self) -> bool {
         matches!(self, SourceCompilationKind::Complete(_))
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -186,7 +186,7 @@ impl fmt::Debug for SparseOutputFilter {
     }
 }
 
-/// Container type for a set of [FilteredSource]
+/// Container type for a mapping from source path to [SourceCompilationKind]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FilteredSources(pub BTreeMap<PathBuf, SourceCompilationKind>);
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -161,10 +161,10 @@ impl SparseOutputFilter {
                 }
                 SourceCompilationKind::Optimized(_) => {
                     trace!("using pruned output selection for {}", file.display());
-                    settings
-                        .output_selection
-                        .as_mut()
-                        .insert(format!("{}", file.display()), OutputSelection::empty_file_output_select());
+                    settings.output_selection.as_mut().insert(
+                        format!("{}", file.display()),
+                        OutputSelection::empty_file_output_select(),
+                    );
                 }
             }
         }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -180,7 +180,7 @@ impl From<Box<dyn FileFilter>> for SparseOutputFilter {
 impl fmt::Debug for SparseOutputFilter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            SparseOutputFilter::Optimized => f.write_str("AllDirty"),
+            SparseOutputFilter::Optimized => f.write_str("Optimized"),
             SparseOutputFilter::Custom(_) => f.write_str("Custom"),
         }
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -57,7 +57,7 @@ pub enum SparseOutputFilter {
     /// In other words, we request the output of solc only for files that have been detected as
     /// _dirty_.
     #[default]
-    AllDirty,
+    Optimized,
     /// Apply an additional filter to [FilteredSources] to
     Custom(Box<dyn FileFilter>),
 }
@@ -79,9 +79,9 @@ impl SparseOutputFilter {
         graph: &GraphEdges,
     ) -> Sources {
         match self {
-            SparseOutputFilter::AllDirty => {
-                if !sources.all_dirty() {
-                    Self::all_dirty(&sources, settings)
+            SparseOutputFilter::Optimized => {
+                if !sources.all_complete() {
+                    Self::optimize(&sources, settings)
                 }
             }
             SparseOutputFilter::Custom(f) => {
@@ -114,7 +114,7 @@ impl SparseOutputFilter {
 
         for (file, source) in sources.0.iter() {
             let key = format!("{}", file.display());
-            if source.is_dirty() && f.is_match(file) {
+            if source.is_complete() && f.is_match(file) {
                 settings.output_selection.as_mut().insert(key, selection.clone());
 
                 // the filter might not cover link references that will be required by the file, so
@@ -137,11 +137,11 @@ impl SparseOutputFilter {
     }
 
     /// prunes all clean sources and only selects an output for dirty sources
-    fn all_dirty(sources: &FilteredSources, settings: &mut Settings) {
+    fn optimize(sources: &FilteredSources, settings: &mut Settings) {
         // settings can be optimized
         trace!(
             "optimizing output selection for {}/{} sources",
-            sources.clean().count(),
+            sources.optimized().count(),
             sources.len()
         );
 
@@ -151,18 +151,21 @@ impl SparseOutputFilter {
             .remove("*")
             .unwrap_or_else(OutputSelection::default_file_output_selection);
 
-        for (file, source) in sources.0.iter() {
-            if source.is_dirty() {
-                settings
-                    .output_selection
-                    .as_mut()
-                    .insert(format!("{}", file.display()), selection.clone());
-            } else {
-                trace!("using pruned output selection for {}", file.display());
-                settings.output_selection.as_mut().insert(
-                    format!("{}", file.display()),
-                    OutputSelection::empty_file_output_select(),
-                );
+        for (file, kind) in sources.0.iter() {
+            match kind {
+                SourceCompilationKind::Complete(_) => {
+                    settings
+                        .output_selection
+                        .as_mut()
+                        .insert(format!("{}", file.display()), selection.clone());
+                }
+                SourceCompilationKind::Optimized(_) => {
+                    trace!("using pruned output selection for {}", file.display());
+                    settings
+                        .output_selection
+                        .as_mut()
+                        .insert(format!("{}", file.display()), OutputSelection::empty_file_output_select());
+                }
             }
         }
     }
@@ -177,7 +180,7 @@ impl From<Box<dyn FileFilter>> for SparseOutputFilter {
 impl fmt::Debug for SparseOutputFilter {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            SparseOutputFilter::AllDirty => f.write_str("AllDirty"),
+            SparseOutputFilter::Optimized => f.write_str("AllDirty"),
             SparseOutputFilter::Custom(_) => f.write_str("Custom"),
         }
     }
@@ -185,7 +188,7 @@ impl fmt::Debug for SparseOutputFilter {
 
 /// Container type for a set of [FilteredSource]
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FilteredSources(pub BTreeMap<PathBuf, FilteredSource>);
+pub struct FilteredSources(pub BTreeMap<PathBuf, SourceCompilationKind>);
 
 impl FilteredSources {
     pub fn is_empty(&self) -> bool {
@@ -196,24 +199,24 @@ impl FilteredSources {
         self.0.len()
     }
 
-    /// Returns `true` if all files are dirty
-    pub fn all_dirty(&self) -> bool {
-        self.0.values().all(|s| s.is_dirty())
+    /// Returns `true` if no sources should have optimized output selection.
+    pub fn all_complete(&self) -> bool {
+        self.0.values().all(|s| s.is_complete())
     }
 
-    /// Returns all entries that are dirty
-    pub fn dirty(&self) -> impl Iterator<Item = (&PathBuf, &FilteredSource)> + '_ {
-        self.0.iter().filter(|(_, s)| s.is_dirty())
+    /// Returns all entries that should not be optimized.
+    pub fn complete(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
+        self.0.iter().filter(|(_, s)| s.is_complete())
     }
 
-    /// Returns all entries that are clean
-    pub fn clean(&self) -> impl Iterator<Item = (&PathBuf, &FilteredSource)> + '_ {
-        self.0.iter().filter(|(_, s)| !s.is_dirty())
+    /// Returns all entries that should be optimized.
+    pub fn optimized(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
+        self.0.iter().filter(|(_, s)| !s.is_complete())
     }
 
-    /// Returns all dirty files
-    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
-        self.0.iter().filter_map(|(k, s)| s.is_dirty().then_some(k))
+    /// Returns all files that should not be optimized.
+    pub fn complete_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
+        self.0.iter().filter_map(|(k, s)| s.is_complete().then_some(k))
     }
 }
 
@@ -225,75 +228,59 @@ impl From<FilteredSources> for Sources {
 
 impl From<Sources> for FilteredSources {
     fn from(s: Sources) -> Self {
-        FilteredSources(s.into_iter().map(|(key, val)| (key, FilteredSource::Dirty(val))).collect())
+        FilteredSources(
+            s.into_iter().map(|(key, val)| (key, SourceCompilationKind::Complete(val))).collect(),
+        )
     }
 }
 
-impl From<BTreeMap<PathBuf, FilteredSource>> for FilteredSources {
-    fn from(s: BTreeMap<PathBuf, FilteredSource>) -> Self {
+impl From<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
+    fn from(s: BTreeMap<PathBuf, SourceCompilationKind>) -> Self {
         FilteredSources(s)
     }
 }
 
-impl AsRef<BTreeMap<PathBuf, FilteredSource>> for FilteredSources {
-    fn as_ref(&self) -> &BTreeMap<PathBuf, FilteredSource> {
+impl AsRef<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
+    fn as_ref(&self) -> &BTreeMap<PathBuf, SourceCompilationKind> {
         &self.0
     }
 }
 
-impl AsMut<BTreeMap<PathBuf, FilteredSource>> for FilteredSources {
-    fn as_mut(&mut self) -> &mut BTreeMap<PathBuf, FilteredSource> {
+impl AsMut<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
+    fn as_mut(&mut self) -> &mut BTreeMap<PathBuf, SourceCompilationKind> {
         &mut self.0
     }
 }
 
 /// Represents the state of a filtered [Source]
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub enum FilteredSource {
-    /// A source that fits the _dirty_ criteria
-    Dirty(Source),
-    /// A source that does _not_ fit the _dirty_ criteria but is included in the filtered set
-    /// because a _dirty_ file pulls it in, either directly on indirectly.
-    Clean(Source),
+pub enum SourceCompilationKind {
+    /// We need a complete compilation output for the source.
+    Complete(Source),
+    /// A source for which we don't need a complete output and want to optimize its compilation by
+    /// reducing output selection.
+    Optimized(Source),
 }
 
-impl FilteredSource {
+impl SourceCompilationKind {
     /// Returns the underlying source
     pub fn source(&self) -> &Source {
         match self {
-            FilteredSource::Dirty(s) => s,
-            FilteredSource::Clean(s) => s,
+            SourceCompilationKind::Complete(s) => s,
+            SourceCompilationKind::Optimized(s) => s,
         }
     }
 
     /// Consumes the type and returns the underlying source
     pub fn into_source(self) -> Source {
         match self {
-            FilteredSource::Dirty(s) => s,
-            FilteredSource::Clean(s) => s,
+            SourceCompilationKind::Complete(s) => s,
+            SourceCompilationKind::Optimized(s) => s,
         }
     }
 
-    /// Whether this file is actually dirt
-    pub fn is_dirty(&self) -> bool {
-        matches!(self, FilteredSource::Dirty(_))
+    /// Whether this file should be compiled with full output selection
+    pub fn is_complete(&self) -> bool {
+        matches!(self, SourceCompilationKind::Complete(_))
     }
-}
-
-/// Helper type that determines the state of a source file
-#[derive(Debug)]
-pub struct FilteredSourceInfo {
-    /// Path to the source file.
-    pub file: PathBuf,
-
-    /// Contents of the file.
-    pub source: Source,
-
-    /// Index in the [GraphEdges].
-    pub idx: usize,
-
-    /// Whether this file is actually dirty.
-    ///
-    /// See also `ArtifactsCacheInner::is_dirty`
-    pub dirty: bool,
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -80,7 +80,7 @@ impl SparseOutputFilter {
     ) -> Sources {
         match self {
             SparseOutputFilter::Optimized => {
-                if !sources.all_complete() {
+                if !sources.all_dirty() {
                     Self::optimize(&sources, settings)
                 }
             }
@@ -141,7 +141,7 @@ impl SparseOutputFilter {
         // settings can be optimized
         trace!(
             "optimizing output selection for {}/{} sources",
-            sources.optimized().count(),
+            sources.clean().count(),
             sources.len()
         );
 
@@ -200,22 +200,22 @@ impl FilteredSources {
     }
 
     /// Returns `true` if no sources should have optimized output selection.
-    pub fn all_complete(&self) -> bool {
+    pub fn all_dirty(&self) -> bool {
         self.0.values().all(|s| s.is_complete())
     }
 
     /// Returns all entries that should not be optimized.
-    pub fn complete(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
+    pub fn dirty(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
         self.0.iter().filter(|(_, s)| s.is_complete())
     }
 
     /// Returns all entries that should be optimized.
-    pub fn optimized(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
+    pub fn clean(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
         self.0.iter().filter(|(_, s)| !s.is_complete())
     }
 
     /// Returns all files that should not be optimized.
-    pub fn complete_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
+    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
         self.0.iter().filter_map(|(k, s)| s.is_complete().then_some(k))
     }
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -3519,8 +3519,8 @@ fn can_detect_config_changes() {
     let compiled = project.compile().unwrap();
     compiled.assert_success();
 
-    let cache = SolFilesCache::read(&project.paths().cache).unwrap();
-    assert_eq!(cache.files.len(), 2);
+    let cache_before = SolFilesCache::read(&project.paths().cache).unwrap();
+    assert_eq!(cache_before.files.len(), 2);
 
     // nothing to compile
     let compiled = project.compile().unwrap();
@@ -3531,6 +3531,9 @@ fn can_detect_config_changes() {
     let compiled = project.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
+
+    let cache_after = SolFilesCache::read(&project.paths().cache).unwrap();
+    assert_ne!(cache_before, cache_after);
 }
 
 #[test]


### PR DESCRIPTION
Currently we are not keeping cache entries for files which were out of scope of compiler (might be dirty or not)

Because of that, when running `forge compile`, then running `forge compile --skip ...` which will filter some artifacts out, and then running `forge compile` again, some artifacts will be recompiled, because `--skip` run removed those entries from cache.

Solution is to keep those entries in cache (we already silently keep artifacts anyway).