### PR TITLE
fix: dirty files detection

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -683,6 +683,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         false
     }
 
+    // Walks over all cache entires, detects dirty files and removes them from cache.
     fn find_and_remove_dirty(&mut self) {
         fn populate_dirty_files(
             file: &Path,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -707,7 +707,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
         // Read all sources, removing entries on I/O errors.
         for file in &files {
-            let Ok(source) = Source::read(&file) else {
+            let Ok(source) = Source::read(file) else {
                 self.dirty_sources.insert(file.clone());
                 continue;
             };
@@ -729,7 +729,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
         // Pre-add all sources that are guaranteed to be dirty
         for file in sources.keys() {
-            if self.is_dirty_impl(&file) {
+            if self.is_dirty_impl(file) {
                 self.dirty_sources.insert(file.clone());
             }
         }
@@ -741,7 +741,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
 
         // Remove all dirty files from cache.
         for file in &self.dirty_sources {
-            self.cache.remove(&file);
+            self.cache.remove(file);
         }
     }
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -700,8 +700,9 @@ mod tests {
         let compiler = ProjectCompiler::new(&project).unwrap();
         let prep = compiler.preprocess().unwrap();
         let cache = prep.cache.as_cached().unwrap();
-        // ensure that cache is cleared
-        assert_eq!(cache.cache.files.len(), 0);
+        // ensure that we have exactly 3 empty entries which will be filled on compilation.
+        assert_eq!(cache.cache.files.len(), 3);
+        assert!(cache.cache.files.values().all(|v| v.artifacts.is_empty()));
 
         let compiled = prep.compile().unwrap();
         assert_eq!(compiled.output.contracts.files().count(), 3);

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -700,8 +700,8 @@ mod tests {
         let compiler = ProjectCompiler::new(&project).unwrap();
         let prep = compiler.preprocess().unwrap();
         let cache = prep.cache.as_cached().unwrap();
-        // 3 contracts
-        assert_eq!(cache.dirty_sources.len(), 3);
+        // ensure that cache is cleared
+        assert_eq!(cache.cache.files.len(), 0);
 
         let compiled = prep.compile().unwrap();
         assert_eq!(compiled.output.contracts.files().count(), 3);

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -424,10 +424,7 @@ impl CompilerSources {
             sources: VersionedSources,
             cache: &mut ArtifactsCache<'_, T>,
         ) -> VersionedFilteredSources {
-            // fill all content hashes first so they're available for all source sets
-            sources.iter().for_each(|(_, (_, sources))| {
-                cache.fill_content_hashes(sources);
-            });
+            cache.remove_dirty_sources();
 
             sources
                 .into_iter()


### PR DESCRIPTION
Follow-up to #104. Right now we detect and remove dirty cache entries in `ArtifactsCacheInner::filter` which is redundant as we can just do a single iteration over all cached files.

Now file filtering is done in 2 steps:
1. `ArtifactsCacheInner::find_and_remove_dirty` detects all dirty entries (even those that are not in scope of current compiler run) and removes them from cache.
2. `ArtifactsCacheInner::filter` schedules for compilation all sources for which we are missing artifacts (either because of removed entry or because we never compiled given source with current version)