### PR TITLE
fix: use serde default for optimizer

### DIFF
--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -270,6 +270,8 @@ pub struct Settings {
     pub stop_after: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub remappings: Vec<Remapping>,
+    /// Custom Optimizer settings
+    #[serde(default)]
     pub optimizer: Optimizer,
     /// Model Checker options.
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
closes https://github.com/foundry-rs/block-explorers/issues/38