### PR TITLE
fix: absolute paths in build info

### DIFF
--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -1648,18 +1648,6 @@ impl CompilerOutput {
         self.contracts.extend(other.contracts);
         self.sources.extend(other.sources);
     }
-
-    pub fn join_all(&mut self, root: impl AsRef<Path>) {
-        let root = root.as_ref();
-        self.contracts = std::mem::take(&mut self.contracts)
-            .into_iter()
-            .map(|(path, contracts)| (root.join(path), contracts))
-            .collect();
-        self.sources = std::mem::take(&mut self.sources)
-            .into_iter()
-            .map(|(path, source)| (root.join(path), source))
-            .collect();
-    }
 }
 
 /// A wrapper helper type for the `Contracts` type alias

--- a/src/compilers/solc/mod.rs
+++ b/src/compilers/solc/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 use semver::Version;
 use std::{
     collections::{BTreeMap, BTreeSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 impl Compiler for Solc {
@@ -31,20 +31,8 @@ impl Compiler for Solc {
     type ParsedSource = SolData;
     type Settings = SolcSettings;
 
-    fn compile(
-        &self,
-        mut input: Self::Input,
-    ) -> Result<(Self::Input, CompilerOutput<Self::CompilationError>)> {
-        if let Some(base_path) = self.base_path.clone() {
-            // Strip prefix from all sources to ensure deterministic metadata.
-            input.strip_prefix(base_path);
-        }
-
-        let mut solc_output = self.compile(&input)?;
-
-        if let Some(ref base_path) = self.base_path {
-            solc_output.join_all(base_path);
-        }
+    fn compile(&self, input: &Self::Input) -> Result<CompilerOutput<Self::CompilationError>> {
+        let solc_output = self.compile(&input)?;
 
         let output = CompilerOutput {
             errors: solc_output.errors,
@@ -52,7 +40,7 @@ impl Compiler for Solc {
             sources: solc_output.sources,
         };
 
-        Ok((input, output))
+        Ok(output)
     }
 
     fn version(&self) -> &Version {
@@ -122,6 +110,10 @@ impl CompilerInput for SolcInput {
 
     fn compiler_name(&self) -> String {
         "Solc".to_string()
+    }
+
+    fn strip_prefix(&mut self, base: &Path) {
+        self.strip_prefix(base)
     }
 }
 

--- a/src/compilers/vyper/input.rs
+++ b/src/compilers/vyper/input.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use super::settings::VyperSettings;
 use crate::{artifacts::Sources, compilers::CompilerInput};
 use semver::Version;
@@ -23,5 +25,12 @@ impl CompilerInput for VyperInput {
 
     fn compiler_name(&self) -> String {
         "Vyper".to_string()
+    }
+
+    fn strip_prefix(&mut self, base: &Path) {
+        self.sources = std::mem::take(&mut self.sources)
+            .into_iter()
+            .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
+            .collect();
     }
 }

--- a/src/compilers/vyper/mod.rs
+++ b/src/compilers/vyper/mod.rs
@@ -150,10 +150,8 @@ impl Compiler for Vyper {
     type ParsedSource = VyperParsedSource;
     type Input = VyperInput;
 
-    fn compile(&self, input: Self::Input) -> Result<(Self::Input, VyperCompilerOutput)> {
-        let output = self.compile(&input)?;
-
-        Ok((input, output))
+    fn compile(&self, input: &Self::Input) -> Result<VyperCompilerOutput> {
+        self.compile(input)
     }
 
     fn version(&self) -> &Version {


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/7878

Removes paths stripping logic from solc implementation, instead we now use `CompilerInput::strip_prefix` and `CompilerOutput::join_all` directly in `compile_*` functions, and only join output paths after writing build info.