### PR TITLE
chore: swap generics on `Project`

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -553,7 +553,7 @@ pub(crate) struct ArtifactsCacheInner<'a, T: ArtifactOutput, C: Compiler> {
     pub edges: GraphEdges<C::ParsedSource>,
 
     /// The project.
-    pub project: &'a Project<T, C>,
+    pub project: &'a Project<C, T>,
 
     /// Files that were invalidated and removed from cache.
     /// Those are not grouped by version and purged completely.
@@ -795,19 +795,19 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
 #[derive(Debug)]
 pub(crate) enum ArtifactsCache<'a, T: ArtifactOutput, C: Compiler> {
     /// Cache nothing on disk
-    Ephemeral(GraphEdges<C::ParsedSource>, &'a Project<T, C>),
+    Ephemeral(GraphEdges<C::ParsedSource>, &'a Project<C, T>),
     /// Handles the actual cached artifacts, detects artifacts that can be reused
     Cached(ArtifactsCacheInner<'a, T, C>),
 }
 
 impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
     /// Create a new cache instance with the given files
-    pub fn new(project: &'a Project<T, C>, edges: GraphEdges<C::ParsedSource>) -> Result<Self> {
+    pub fn new(project: &'a Project<C, T>, edges: GraphEdges<C::ParsedSource>) -> Result<Self> {
         /// Returns the [SolFilesCache] to use
         ///
         /// Returns a new empty cache if the cache does not exist or `invalidate_cache` is set.
         fn get_cache<T: ArtifactOutput, C: Compiler>(
-            project: &Project<T, C>,
+            project: &Project<C, T>,
             invalidate_cache: bool,
         ) -> CompilerCache<C::Settings> {
             // the currently configured paths
@@ -893,7 +893,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
         }
     }
 
-    pub fn project(&self) -> &'a Project<T, C> {
+    pub fn project(&self) -> &'a Project<C, T> {
         match self {
             ArtifactsCache::Ephemeral(_, project) => project,
             ArtifactsCache::Cached(cache) => cache.project,

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -713,7 +713,7 @@ mod tests {
     use super::*;
     use crate::{
         artifacts::output_selection::ContractOutputSelection, project_util::TempProject,
-        ConfigurableArtifacts, MinimalCombinedArtifacts,
+        ConfigurableArtifacts, MinimalCombinedArtifacts, Solc,
     };
 
     fn init_tracing() {
@@ -746,7 +746,7 @@ mod tests {
     fn can_detect_cached_files() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/dapp-sample");
         let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
-        let project = TempProject::<MinimalCombinedArtifacts>::new(paths).unwrap();
+        let project = TempProject::<Solc, MinimalCombinedArtifacts>::new(paths).unwrap();
 
         let compiled = project.compile().unwrap();
         compiled.assert_success();
@@ -880,7 +880,7 @@ mod tests {
     fn extra_output_cached() {
         let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/dapp-sample");
         let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
-        let mut project = TempProject::<ConfigurableArtifacts>::new(paths.clone()).unwrap();
+        let mut project = TempProject::new(paths.clone()).unwrap();
 
         // Compile once without enabled extra output
         project.compile().unwrap();

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -121,7 +121,7 @@ use std::{path::PathBuf, sync::Arc, time::Instant};
 pub struct ProjectCompiler<'a, T: ArtifactOutput, C: Compiler> {
     /// Contains the relationship of the source files and their imports
     edges: GraphEdges<C::ParsedSource>,
-    project: &'a Project<T, C>,
+    project: &'a Project<C, T>,
     /// how to compile all the sources
     sources: CompilerSources<C>,
     /// How to select solc [`crate::artifacts::CompilerOutput`] for files
@@ -131,7 +131,7 @@ pub struct ProjectCompiler<'a, T: ArtifactOutput, C: Compiler> {
 impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
     /// Create a new `ProjectCompiler` to bootstrap the compilation process of the project's
     /// sources.
-    pub fn new(project: &'a Project<T, C>) -> Result<Self> {
+    pub fn new(project: &'a Project<C, T>) -> Result<Self> {
         Self::with_sources(project, project.paths.read_input_files()?)
     }
 
@@ -141,7 +141,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
     ///
     /// Multiple (`Solc` -> `Sources`) pairs can be compiled in parallel if the `Project` allows
     /// multiple `jobs`, see [`crate::Project::set_solc_jobs()`].
-    pub fn with_sources(project: &'a Project<T, C>, sources: Sources) -> Result<Self> {
+    pub fn with_sources(project: &'a Project<C, T>, sources: Sources) -> Result<Self> {
         match &project.compiler_config {
             CompilerConfig::Specific(compiler) => {
                 Self::with_sources_and_compiler(project, sources, compiler.clone())
@@ -154,7 +154,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
 
     /// Compiles the sources automatically detecting versions via [CompilerVersionManager]
     pub fn with_sources_and_version_manager<VM: CompilerVersionManager<Compiler = C>>(
-        project: &'a Project<T, C>,
+        project: &'a Project<C, T>,
         sources: Sources,
         version_manager: VM,
     ) -> Result<Self> {
@@ -176,7 +176,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
 
     /// Compiles the sources with a pinned [Compiler] instance
     pub fn with_sources_and_compiler(
-        project: &'a Project<T, C>,
+        project: &'a Project<C, T>,
         sources: Sources,
         compiler: C,
     ) -> Result<Self> {

--- a/src/compilers/vyper/error.rs
+++ b/src/compilers/vyper/error.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VyperSourceLocation {
     file: PathBuf,
     #[serde(rename = "lineno")]
@@ -16,7 +16,7 @@ pub struct VyperSourceLocation {
     offset: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct VyperCompilationError {
     pub message: String,

--- a/src/compilers/vyper/mod.rs
+++ b/src/compilers/vyper/mod.rs
@@ -88,6 +88,8 @@ impl Vyper {
         // Only run UTF-8 validation once.
         let output = std::str::from_utf8(&output).map_err(|_| SolcError::InvalidUtf8)?;
 
+        trace!("vyper compiler output: {}", output);
+
         Ok(serde_json::from_str(output)?)
     }
 

--- a/src/compilers/vyper/settings.rs
+++ b/src/compilers/vyper/settings.rs
@@ -22,8 +22,10 @@ pub struct VyperSettings {
     )]
     pub evm_version: Option<EvmVersion>,
     /// Optimization mode
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub optimize: Option<VyperOptimizationMode>,
     /// Whether or not the bytecode should include Vyper's signature
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bytecode_metadata: Option<bool>,
     pub output_selection: OutputSelection,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl Default for CompilerConfig<Solc> {
 
 /// Represents a project workspace and handles `solc` compiling of all contracts in that workspace.
 #[derive(Clone, Debug)]
-pub struct Project<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler = Solc> {
+pub struct Project<C: Compiler = Solc, T: ArtifactOutput = ConfigurableArtifacts> {
     pub compiler_config: CompilerConfig<C>,
     /// The layout of the project
     pub paths: ProjectPathsConfig<C>,
@@ -159,14 +159,14 @@ impl Project {
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> Project<T, C> {
+impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Returns the handler that takes care of processing all artifacts
     pub fn artifacts_handler(&self) -> &T {
         &self.artifacts
     }
 }
 
-impl<T: ArtifactOutput> Project<T> {
+impl<T: ArtifactOutput> Project<Solc, T> {
     /// Returns standard-json-input to compile the target contract
     pub fn standard_json_input(
         &self,
@@ -225,7 +225,7 @@ impl<T: ArtifactOutput> Project<T> {
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> Project<T, C> {
+impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Returns the path to the artifacts directory
     pub fn artifacts_path(&self) -> &PathBuf {
         &self.paths.artifacts
@@ -745,7 +745,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectBuilder<T, C> {
         }
     }
 
-    pub fn build(self, compiler_config: CompilerConfig<C>) -> Result<Project<T, C>> {
+    pub fn build(self, compiler_config: CompilerConfig<C>) -> Result<Project<C, T>> {
         let Self {
             paths,
             cached,
@@ -794,7 +794,7 @@ impl<T: ArtifactOutput + Default> Default for ProjectBuilder<T> {
     }
 }
 
-impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<T, C> {
+impl<T: ArtifactOutput, C: Compiler> ArtifactOutput for Project<C, T> {
     type Artifact = T::Artifact;
 
     fn on_output<CP>(

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -38,7 +38,10 @@ pub struct TempProject<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler = 
 
 impl<T: ArtifactOutput> TempProject<T> {
     /// Makes sure all resources are created
-    pub fn create_new(root: TempDir, inner: Project<Solc, T>) -> std::result::Result<Self, SolcIoError> {
+    pub fn create_new(
+        root: TempDir,
+        inner: Project<Solc, T>,
+    ) -> std::result::Result<Self, SolcIoError> {
         let mut project = Self { _root: root, inner };
         project.paths().create_all()?;
         // ignore license warnings

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -33,12 +33,12 @@ pub struct TempProject<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler = 
     /// temporary workspace root
     _root: TempDir,
     /// actual project workspace with the `root` tempdir as its root
-    inner: Project<T, C>,
+    inner: Project<C, T>,
 }
 
 impl<T: ArtifactOutput> TempProject<T> {
     /// Makes sure all resources are created
-    pub fn create_new(root: TempDir, inner: Project<T>) -> std::result::Result<Self, SolcIoError> {
+    pub fn create_new(root: TempDir, inner: Project<Solc, T>) -> std::result::Result<Self, SolcIoError> {
         let mut project = Self { _root: root, inner };
         project.paths().create_all()?;
         // ignore license warnings
@@ -87,7 +87,7 @@ impl<T: ArtifactOutput> TempProject<T> {
         self
     }
 
-    pub fn project(&self) -> &Project<T> {
+    pub fn project(&self) -> &Project<Solc, T> {
         &self.inner
     }
 
@@ -95,7 +95,7 @@ impl<T: ArtifactOutput> TempProject<T> {
         self.project().flatten(target)
     }
 
-    pub fn project_mut(&mut self) -> &mut Project<T> {
+    pub fn project_mut(&mut self) -> &mut Project<Solc, T> {
         &mut self.inner
     }
 
@@ -472,8 +472,8 @@ impl TempProject<ConfigurableArtifacts> {
     }
 }
 
-impl<T: ArtifactOutput> AsRef<Project<T>> for TempProject<T> {
-    fn as_ref(&self) -> &Project<T> {
+impl<T: ArtifactOutput> AsRef<Project<Solc, T>> for TempProject<T> {
+    fn as_ref(&self) -> &Project<Solc, T> {
         self.project()
     }
 }

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -29,14 +29,14 @@ pub mod mock;
 /// A [`Project`] wrapper that lives in a new temporary directory
 ///
 /// Once `TempProject` is dropped, the temp dir is automatically removed, see [`TempDir::drop()`]
-pub struct TempProject<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler = Solc> {
+pub struct TempProject<C: Compiler = Solc, T: ArtifactOutput = ConfigurableArtifacts> {
     /// temporary workspace root
     _root: TempDir,
     /// actual project workspace with the `root` tempdir as its root
     inner: Project<C, T>,
 }
 
-impl<T: ArtifactOutput> TempProject<T> {
+impl<T: ArtifactOutput> TempProject<Solc, T> {
     /// Makes sure all resources are created
     pub fn create_new(
         root: TempDir,
@@ -350,7 +350,7 @@ contract {} {{}}
     }
 }
 
-impl<T: ArtifactOutput + Default> TempProject<T> {
+impl<T: ArtifactOutput + Default> TempProject<Solc, T> {
     /// Creates a new temp project inside a tempdir with a prefixed directory
     #[cfg(feature = "svm-solc")]
     pub fn prefixed(prefix: &str, paths: ProjectPathsConfigBuilder) -> Result<Self> {
@@ -375,7 +375,7 @@ impl<T: ArtifactOutput + Default> TempProject<T> {
     }
 }
 
-impl<T: ArtifactOutput> fmt::Debug for TempProject<T> {
+impl<T: ArtifactOutput> fmt::Debug for TempProject<Solc, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TempProject").field("paths", self.paths()).finish()
     }
@@ -400,7 +400,7 @@ fn contract_file_name(name: impl AsRef<str>) -> String {
 }
 
 #[cfg(feature = "svm-solc")]
-impl TempProject<HardhatArtifacts> {
+impl TempProject<Solc, HardhatArtifacts> {
     /// Creates an empty new hardhat style workspace in a new temporary dir
     pub fn hardhat() -> Result<Self> {
         let tmp_dir = tempdir("tmp_hh")?;
@@ -416,7 +416,7 @@ impl TempProject<HardhatArtifacts> {
 }
 
 #[cfg(feature = "svm-solc")]
-impl TempProject<ConfigurableArtifacts> {
+impl TempProject {
     /// Creates an empty new dapptools style workspace in a new temporary dir
     pub fn dapptools() -> Result<Self> {
         let tmp_dir = tempdir("tmp_dapp")?;
@@ -475,7 +475,7 @@ impl TempProject<ConfigurableArtifacts> {
     }
 }
 
-impl<T: ArtifactOutput> AsRef<Project<Solc, T>> for TempProject<T> {
+impl<T: ArtifactOutput> AsRef<Project<Solc, T>> for TempProject<Solc, T> {
     fn as_ref(&self) -> &Project<Solc, T> {
         self.project()
     }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -6,11 +6,24 @@ use foundry_compilers::{
         output_selection::OutputSelection, BytecodeHash, DevDoc, Error, ErrorDoc, EventDoc,
         Libraries, MethodDoc, ModelCheckerEngine::CHC, ModelCheckerSettings, Settings, Severity,
         UserDoc, UserDocNotice,
-    }, buildinfo::BuildInfo, cache::{CompilerCache, SOLIDITY_FILES_CACHE_FILENAME}, compilers::{
+    },
+    buildinfo::BuildInfo,
+    cache::{CompilerCache, SOLIDITY_FILES_CACHE_FILENAME},
+    compilers::{
         solc::SolcVersionManager,
         vyper::{Vyper, VyperSettings},
         CompilerOutput, CompilerVersionManager,
-    }, error::SolcError, flatten::Flattener, info::ContractInfo, project_util::*, remappings::Remapping, resolver::parse::SolData, utils::{self, RuntimeOrHandle}, Artifact, CompilerConfig, ConfigurableArtifacts, ExtraOutputValues, Graph, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, Solc, SolcInput, SolcSparseFileFilter, TestFileFilter
+    },
+    error::SolcError,
+    flatten::Flattener,
+    info::ContractInfo,
+    project_util::*,
+    remappings::Remapping,
+    resolver::parse::SolData,
+    utils::{self, RuntimeOrHandle},
+    Artifact, CompilerConfig, ConfigurableArtifacts, ExtraOutputValues, Graph, Project,
+    ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, Solc, SolcInput,
+    SolcSparseFileFilter, TestFileFilter,
 };
 use pretty_assertions::assert_eq;
 use semver::Version;


### PR DESCRIPTION
Changes order of generics on `Project`. We'll be doing a lot of `Project<C>` and most of the time we use the same `ConfigurableArtifacts`