### PR TITLE
feat: Vyper imports parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ sha2 = { version = "0.10", default-features = false, optional = true }
 itertools = "0.12"
 auto_impl = "1"
 
+winnow = "0.6"
+
 [dev-dependencies]
 alloy-primitives = { version = "0.7", features = ["serde", "rand"] }
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     artifacts::{
-        output_selection::OutputSelection, Contract, FileToContractsMap, SourceFile, Sources,
+        output_selection::{FileOutputSelection, OutputSelection},
+        Contract, FileToContractsMap, SourceFile, Sources,
     },
     error::Result,
     remappings::Remapping,
@@ -32,6 +33,11 @@ pub trait CompilerSettings:
     /// Ensures that all settings fields are equal except for `output_selection` which is required
     /// to be a subset of `cached.output_selection`.
     fn can_use_cached(&self, other: &Self) -> bool;
+
+    /// Returns minimal output selection which can be used to optimize compilation.
+    fn minimal_output_selection() -> FileOutputSelection {
+        BTreeMap::from([("*".to_string(), vec![])])
+    }
 }
 
 /// Input of a compiler, including sources and settings used for their compilation.
@@ -63,7 +69,7 @@ pub trait CompilerInput: Serialize + Send + Sync + Sized {
 pub trait ParsedSource: Debug + Sized + Send {
     fn parse(content: &str, file: &Path) -> Self;
     fn version_req(&self) -> Option<&VersionReq>;
-    fn resolve_imports<C>(&self, paths: &ProjectPathsConfig<C>) -> Vec<PathBuf>;
+    fn resolve_imports<C>(&self, paths: &ProjectPathsConfig<C>) -> Result<Vec<PathBuf>>;
 }
 
 /// Error returned by compiler. Might also represent a warning or informational message.

--- a/src/compilers/solc/mod.rs
+++ b/src/compilers/solc/mod.rs
@@ -176,8 +176,8 @@ impl ParsedSource for SolData {
         self.version_req.as_ref()
     }
 
-    fn resolve_imports<C>(&self, _paths: &crate::ProjectPathsConfig<C>) -> Vec<PathBuf> {
-        return self.imports.iter().map(|i| i.data().path().to_path_buf()).collect_vec();
+    fn resolve_imports<C>(&self, _paths: &crate::ProjectPathsConfig<C>) -> Result<Vec<PathBuf>> {
+        return Ok(self.imports.iter().map(|i| i.data().path().to_path_buf()).collect_vec());
     }
 }
 

--- a/src/compilers/vyper/input.rs
+++ b/src/compilers/vyper/input.rs
@@ -32,5 +32,7 @@ impl CompilerInput for VyperInput {
             .into_iter()
             .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
             .collect();
+
+        self.settings.strip_prefix(base)
     }
 }

--- a/src/compilers/vyper/parser.rs
+++ b/src/compilers/vyper/parser.rs
@@ -1,28 +1,157 @@
 use crate::{
-    compilers::ParsedSource, resolver::parse::capture_outer_and_inner, utils::RE_VYPER_VERSION,
+    compilers::ParsedSource,
+    error::{Result, SolcError},
+    resolver::parse::capture_outer_and_inner,
+    utils::RE_VYPER_VERSION,
     ProjectPathsConfig,
 };
 use semver::VersionReq;
 use std::path::{Path, PathBuf};
+use winnow::{
+    ascii::space1,
+    combinator::{alt, opt, preceded, separated},
+    token::take_till,
+    PResult, Parser,
+};
 
 #[derive(Debug)]
 pub struct VyperParsedSource {
+    path: PathBuf,
     version_req: Option<VersionReq>,
+    parsed_imports: Vec<Vec<String>>,
 }
 
 impl ParsedSource for VyperParsedSource {
-    fn parse(content: &str, _file: &Path) -> Self {
+    fn parse(content: &str, file: &Path) -> Self {
         let version_req = capture_outer_and_inner(content, &RE_VYPER_VERSION, &["version"])
             .first()
             .and_then(|(cap, _)| VersionReq::parse(cap.as_str()).ok());
-        VyperParsedSource { version_req }
+
+        let parsed_imports = if let Ok(imports) = parse_imports(content) {
+            let mut parsed = Vec::new();
+            for import in imports {
+                parsed.push(import.into_iter().map(|part| part.to_string()).collect());
+            }
+            parsed
+        } else {
+            Vec::new()
+        };
+
+        let path = file.to_path_buf();
+
+        VyperParsedSource { path, version_req, parsed_imports }
     }
 
     fn version_req(&self) -> Option<&VersionReq> {
         self.version_req.as_ref()
     }
 
-    fn resolve_imports<C>(&self, _paths: &ProjectPathsConfig<C>) -> Vec<PathBuf> {
-        vec![]
+    fn resolve_imports<C>(&self, paths: &ProjectPathsConfig<C>) -> Result<Vec<PathBuf>> {
+        let mut imports = Vec::new();
+        'outer: for import in &self.parsed_imports {
+            // skip built-in imports
+            if import[0] == "vyper" {
+                continue;
+            }
+
+            let mut dots_cnt = 0;
+            while dots_cnt < import.len() && import[dots_cnt] == "" {
+                dots_cnt += 1;
+            }
+
+            let mut candidate_dirs = Vec::new();
+
+            if dots_cnt > 0 {
+                let mut candidate_dir = Some(self.path.as_path());
+
+                for _ in 0..dots_cnt {
+                    candidate_dir = candidate_dir.and_then(|dir| dir.parent());
+                }
+
+                let candidate_dir = candidate_dir.ok_or_else(|| {
+                    SolcError::msg(format!(
+                        "Could not go {} levels up for import at {}",
+                        dots_cnt,
+                        self.path.display()
+                    ))
+                })?;
+
+                candidate_dirs.push(candidate_dir);
+            } else {
+                if let Some(parent) = self.path.parent() {
+                    candidate_dirs.push(parent);
+                }
+                candidate_dirs.push(paths.root.as_path());
+            }
+
+            for candidate_dir in candidate_dirs {
+                let mut candidate = candidate_dir.to_path_buf();
+
+                for part in &import[dots_cnt..] {
+                    candidate = candidate.join(part);
+                }
+
+                candidate.set_extension("vy");
+
+                if candidate.exists() {
+                    imports.push(candidate);
+                    continue 'outer;
+                }
+            }
+
+            return Err(SolcError::msg(format!(
+                "failed to resolve import {} at {}",
+                import.join("."),
+                self.path.display()
+            )));
+        }
+        Ok(imports)
+    }
+}
+
+fn parse_imports<'a>(content: &'a str) -> Result<Vec<Vec<&'a str>>> {
+    let mut imports = Vec::new();
+
+    for mut line in content.split('\n') {
+        if let Ok(parts) = parse_import(&mut line) {
+            imports.push(parts);
+        }
+    }
+
+    Ok(imports)
+}
+
+fn parse_import<'a>(input: &mut &'a str) -> PResult<Vec<&'a str>> {
+    (
+        preceded(
+            (alt(["from", "import"]), space1),
+            separated(0.., take_till(0.., ['.', ' ']), '.'),
+        ),
+        opt(preceded((space1, "import", space1), take_till(0.., [' ']))),
+    )
+        .parse_next(input)
+        .map(|(mut parts, last): (Vec<&str>, Option<&str>)| {
+            if let Some(last) = last {
+                parts.push(last);
+            }
+            parts
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use winnow::Parser;
+
+    use super::parse_import;
+
+    #[test]
+    fn can_parse_import() {
+        assert_eq!(parse_import.parse("import one.two.three").unwrap(), ["one", "two", "three"]);
+        assert_eq!(
+            parse_import.parse("from one.two.three import four").unwrap(),
+            ["one", "two", "three", "four"]
+        );
+        assert_eq!(parse_import.parse("from one import two").unwrap(), ["one", "two"]);
+        assert_eq!(parse_import.parse("import one").unwrap(), ["one"]);
     }
 }

--- a/src/compilers/vyper/parser.rs
+++ b/src/compilers/vyper/parser.rs
@@ -126,7 +126,7 @@ fn parse_imports(content: &str) -> Result<Vec<Vec<&str>>> {
     Ok(imports)
 }
 
-/// Parses given input, trying to find (import|from) <part1>.<part2>.<oart3> (import <part4>)?
+/// Parses given input, trying to find (import|from) part1.part2.part3 (import part4)?
 fn parse_import<'a>(input: &mut &'a str) -> PResult<Vec<&'a str>> {
     (
         preceded(

--- a/src/compilers/vyper/parser.rs
+++ b/src/compilers/vyper/parser.rs
@@ -59,8 +59,11 @@ impl ParsedSource for VyperParsedSource {
                 dots_cnt += 1;
             }
 
+            // Potential locations of imported source.
             let mut candidate_dirs = Vec::new();
 
+            // For relative imports, vyper always checks only directory containing contract which
+            // includes given import.
             if dots_cnt > 0 {
                 let mut candidate_dir = Some(self.path.as_path());
 
@@ -78,6 +81,7 @@ impl ParsedSource for VyperParsedSource {
 
                 candidate_dirs.push(candidate_dir);
             } else {
+                // For absolute imports, Vyper firstly checks current directory, and then root.
                 if let Some(parent) = self.path.parent() {
                     candidate_dirs.push(parent);
                 }
@@ -109,6 +113,7 @@ impl ParsedSource for VyperParsedSource {
     }
 }
 
+/// Parses given source trying to find all import directives.
 fn parse_imports(content: &str) -> Result<Vec<Vec<&str>>> {
     let mut imports = Vec::new();
 
@@ -121,6 +126,7 @@ fn parse_imports(content: &str) -> Result<Vec<Vec<&str>>> {
     Ok(imports)
 }
 
+/// Parses given input, trying to find (import|from) <part1>.<part2>.<oart3> (import <part4>)?
 fn parse_import<'a>(input: &mut &'a str) -> PResult<Vec<&'a str>> {
     (
         preceded(

--- a/src/compilers/vyper/parser.rs
+++ b/src/compilers/vyper/parser.rs
@@ -55,7 +55,7 @@ impl ParsedSource for VyperParsedSource {
             }
 
             let mut dots_cnt = 0;
-            while dots_cnt < import.len() && import[dots_cnt] == "" {
+            while dots_cnt < import.len() && import[dots_cnt].is_empty() {
                 dots_cnt += 1;
             }
 
@@ -109,7 +109,7 @@ impl ParsedSource for VyperParsedSource {
     }
 }
 
-fn parse_imports<'a>(content: &'a str) -> Result<Vec<Vec<&'a str>>> {
+fn parse_imports(content: &str) -> Result<Vec<Vec<&str>>> {
     let mut imports = Vec::new();
 
     for mut line in content.split('\n') {

--- a/src/compilers/vyper/settings.rs
+++ b/src/compilers/vyper/settings.rs
@@ -1,5 +1,10 @@
+use std::{collections::BTreeMap, path::Path};
+
 use crate::{
-    artifacts::{output_selection::OutputSelection, serde_helpers},
+    artifacts::{
+        output_selection::{FileOutputSelection, OutputSelection},
+        serde_helpers,
+    },
     compilers::CompilerSettings,
     EvmVersion,
 };
@@ -28,6 +33,27 @@ pub struct VyperSettings {
     pub output_selection: OutputSelection,
 }
 
+impl VyperSettings {
+    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) {
+        let base = base.as_ref();
+
+        self.output_selection = OutputSelection(
+            std::mem::take(&mut self.output_selection.0)
+                .into_iter()
+                .map(|(file, selection)| {
+                    (
+                        Path::new(&file)
+                            .strip_prefix(base)
+                            .map(|p| format!("{}", p.display()))
+                            .unwrap_or(file),
+                        selection,
+                    )
+                })
+                .collect(),
+        );
+    }
+}
+
 impl CompilerSettings for VyperSettings {
     fn output_selection_mut(&mut self) -> &mut OutputSelection {
         &mut self.output_selection
@@ -39,5 +65,10 @@ impl CompilerSettings for VyperSettings {
             && optimize == &other.optimize
             && bytecode_metadata == &other.bytecode_metadata
             && output_selection.is_subset_of(&other.output_selection)
+    }
+
+    fn minimal_output_selection() -> FileOutputSelection {
+        // Vyper throws an error if empty selection is specified, so we are only requesting ABI.
+        BTreeMap::from([("*".to_string(), vec!["abi".to_string()])])
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -192,11 +192,13 @@ impl<D> SparseOutputFilter<D> {
             sources.len()
         );
 
-        let selection = settings
+        let default = settings
             .output_selection_mut()
             .as_mut()
             .remove("*")
             .unwrap_or_else(OutputSelection::default_file_output_selection);
+
+        let optimized = S::minimal_output_selection();
 
         for (file, kind) in sources.0.iter() {
             match kind {
@@ -204,14 +206,14 @@ impl<D> SparseOutputFilter<D> {
                     settings
                         .output_selection_mut()
                         .as_mut()
-                        .insert(format!("{}", file.display()), selection.clone());
+                        .insert(format!("{}", file.display()), default.clone());
                 }
                 SourceCompilationKind::Optimized(_) => {
                     trace!("using pruned output selection for {}", file.display());
-                    settings.output_selection_mut().as_mut().insert(
-                        format!("{}", file.display()),
-                        OutputSelection::empty_file_output_select(),
-                    );
+                    settings
+                        .output_selection_mut()
+                        .as_mut()
+                        .insert(format!("{}", file.display()), optimized.clone());
                 }
             }
         }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -362,14 +362,14 @@ impl<D: ParsedSource> Graph<D> {
         // now we need to resolve all imports for the source file and those imported from other
         // locations
         while let Some((path, node)) = unresolved.pop_front() {
-            let mut resolved_imports = Vec::with_capacity(node.data.resolve_imports(paths).len());
+            let mut resolved_imports = Vec::with_capacity(node.data.resolve_imports(paths)?.len());
             // parent directory of the current file
             let cwd = match path.parent() {
                 Some(inner) => inner,
                 None => continue,
             };
 
-            for import_path in node.data.resolve_imports(paths) {
+            for import_path in node.data.resolve_imports(paths)? {
                 match paths.resolve_import_and_include_paths(
                     cwd,
                     &import_path,


### PR DESCRIPTION
We need to parse Vyper import directives for caching to work correctly.

This PR implements parser which is able to process imports of format `import a.b.c` and `from a.b.c import d`. Relative imports (`from ...a.b.c import d`) are also supported.

Tested on snekmate codebase.


