### PR TITLE
fix: relax trait bounds

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,7 @@ allow = [
     "LicenseRef-ring",
     # https://github.com/briansmith/webpki/issues/148
     "LicenseRef-webpki",
+    "BSL-1.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -73,7 +73,9 @@ pub trait ParsedSource: Debug + Sized + Send {
 }
 
 /// Error returned by compiler. Might also represent a warning or informational message.
-pub trait CompilationError: Serialize + DeserializeOwned + Send + Sync + Display + Debug {
+pub trait CompilationError:
+    Serialize + DeserializeOwned + Send + Sync + Display + Debug + Clone + 'static
+{
     fn is_warning(&self) -> bool;
     fn is_error(&self) -> bool;
     fn source_location(&self) -> Option<crate::artifacts::error::SourceLocation>;


### PR DESCRIPTION
Updates trait bounds to make it easier to work with `ProjectCompileOutput` on foundry side