### PR TITLE
fix: update vyper path resolution logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     }
 }
 
-pub struct ProjectBuilder<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler = Solc> {
+pub struct ProjectBuilder<C: Compiler = Solc, T: ArtifactOutput = ConfigurableArtifacts> {
     /// The layout of the
     paths: Option<ProjectPathsConfig<C>>,
     /// How solc invocation should be configured.
@@ -582,7 +582,7 @@ pub struct ProjectBuilder<T: ArtifactOutput = ConfigurableArtifacts, C: Compiler
     solc_jobs: Option<usize>,
 }
 
-impl<T: ArtifactOutput, C: Compiler> ProjectBuilder<T, C> {
+impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
     /// Create a new builder with the given artifacts handler
     pub fn new(artifacts: T) -> Self {
         Self {
@@ -714,7 +714,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectBuilder<T, C> {
     }
 
     /// Set arbitrary `ArtifactOutputHandler`
-    pub fn artifacts<A: ArtifactOutput>(self, artifacts: A) -> ProjectBuilder<A, C> {
+    pub fn artifacts<A: ArtifactOutput>(self, artifacts: A) -> ProjectBuilder<C, A> {
         let ProjectBuilder {
             paths,
             cached,
@@ -788,7 +788,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectBuilder<T, C> {
     }
 }
 
-impl<T: ArtifactOutput + Default> Default for ProjectBuilder<T> {
+impl<C: Compiler, T: ArtifactOutput + Default> Default for ProjectBuilder<C, T> {
     fn default() -> Self {
         Self::new(T::default())
     }

--- a/test-data/vyper-imports/src/A.vy
+++ b/test-data/vyper-imports/src/A.vy
@@ -1,0 +1,3 @@
+from . import B
+import A as AAlias
+from .module import C

--- a/test-data/vyper-imports/src/B.vy
+++ b/test-data/vyper-imports/src/B.vy
@@ -1,0 +1,1 @@
+from module import D

--- a/test-data/vyper-imports/src/module/C.vy
+++ b/test-data/vyper-imports/src/module/C.vy
@@ -1,0 +1,1 @@
+from .. import B

--- a/test-data/vyper-imports/src/module/inner/E.vy
+++ b/test-data/vyper-imports/src/module/inner/E.vy
@@ -1,0 +1,1 @@
+from ...module.inner import E

--- a/test-data/vyper-imports/src/module/inner/F.vy
+++ b/test-data/vyper-imports/src/module/inner/F.vy
@@ -1,0 +1,1 @@
+import src.module.inner.E as EAlias

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -3884,7 +3884,6 @@ fn test_vyper_imports() {
         ..Default::default()
     };
 
-    // first compile
     let project = ProjectBuilder::<Vyper>::new(Default::default())
         .settings(settings)
         .paths(paths)

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -25,6 +25,7 @@ use foundry_compilers::{
     ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, Solc, SolcInput,
     SolcSparseFileFilter, TestFileFilter,
 };
+use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use semver::Version;
 use std::{
@@ -36,31 +37,33 @@ use std::{
 };
 use svm::{platform, Platform};
 
-async fn install_vyper() -> Vyper {
-    #[cfg(target_family = "unix")]
-    use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+pub static VYPER: Lazy<Vyper> = Lazy::new(|| {
+    RuntimeOrHandle::new().block_on(async {
+        #[cfg(target_family = "unix")]
+        use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
-    let url = match platform() {
-        Platform::MacOsAarch64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.darwin",
-        Platform::LinuxAmd64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.linux",
-        Platform::WindowsAmd64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.windows.exe",
-        _ => panic!("unsupported")
-    };
+        let url = match platform() {
+            Platform::MacOsAarch64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.darwin",
+            Platform::LinuxAmd64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.linux",
+            Platform::WindowsAmd64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.windows.exe",
+            _ => panic!("unsupported")
+        };
 
-    let res = reqwest::Client::builder().build().unwrap().get(url).send().await.unwrap();
+        let res = reqwest::Client::builder().build().unwrap().get(url).send().await.unwrap();
 
-    assert!(res.status().is_success());
+        assert!(res.status().is_success());
 
-    let bytes = res.bytes().await.unwrap();
-    let path = std::env::temp_dir().join("vyper");
+        let bytes = res.bytes().await.unwrap();
+        let path = std::env::temp_dir().join("vyper");
 
-    std::fs::write(&path, bytes).unwrap();
+        std::fs::write(&path, bytes).unwrap();
 
-    #[cfg(target_family = "unix")]
-    std::fs::set_permissions(&path, Permissions::from_mode(0o755)).unwrap();
+        #[cfg(target_family = "unix")]
+        std::fs::set_permissions(&path, Permissions::from_mode(0o755)).unwrap();
 
-    Vyper::new(path).unwrap()
-}
+        Vyper::new(path).unwrap()
+    })
+});
 
 #[test]
 fn can_get_versioned_linkrefs() {
@@ -3823,18 +3826,16 @@ fn can_compile_vyper_with_cache() {
         .build::<Vyper>()
         .unwrap();
 
-    let compiler = RuntimeOrHandle::new().block_on(install_vyper());
-
     let settings = VyperSettings {
         output_selection: OutputSelection::default_output_selection(),
         ..Default::default()
     };
 
     // first compile
-    let project = ProjectBuilder::<ConfigurableArtifacts, Vyper>::new(Default::default())
+    let project = ProjectBuilder::<Vyper>::new(Default::default())
         .settings(settings)
         .paths(paths)
-        .build(CompilerConfig::Specific(compiler))
+        .build(CompilerConfig::Specific(VYPER.clone()))
         .unwrap();
 
     let compiled = project.compile().unwrap();
@@ -3866,4 +3867,30 @@ fn yul_remappings_ignored() {
 
     let compiled = project.compile().unwrap();
     compiled.assert_success();
+}
+
+#[test]
+fn test_vyper_imports() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/vyper-imports");
+
+    let paths = ProjectPathsConfig::builder()
+        .sources(root.join("src"))
+        .root(root)
+        .build::<Vyper>()
+        .unwrap();
+
+    let settings = VyperSettings {
+        output_selection: OutputSelection::default_output_selection(),
+        ..Default::default()
+    };
+
+    // first compile
+    let project = ProjectBuilder::<Vyper>::new(Default::default())
+        .settings(settings)
+        .paths(paths)
+        .no_artifacts()
+        .build(CompilerConfig::Specific(VYPER.clone()))
+        .unwrap();
+
+    project.compile().unwrap().assert_success();
 }


### PR DESCRIPTION
Current Vyper path resolution does not correctly handle relative paths (`from . import X`, `from .. import X`).

This PR fixes this and changes parser to parse into `VyperImport` which tracks `final_part` (X at `from ... import X` expression).

Currently vyper allows doing imports like `from Contract import Contract` which is equivalent to `import Contract as Contract` and only requires `Contract.vy` to be present. However, such format is only supported when invoking `vyper` from command like, and for standard JSON input it does not work, which is why we can't compile snekmate right away without small import fixes.

I believe in the future Vyper versions that will be fixed and thus `VyperImport` tracks `final_part` additionaly.

Also added more tests for path resolution