### PR TITLE
refactor: sparse output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ itertools = "0.13"
 auto_impl = "1"
 
 winnow = "0.6"
+dyn-clone = "1"
+derivative = "2.2"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7", features = ["serde", "rand"] }

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -133,6 +133,26 @@ pub trait ParsedSource: Debug + Sized + Send + Clone {
     fn version_req(&self) -> Option<&VersionReq>;
     fn resolve_imports<C>(&self, paths: &ProjectPathsConfig<C>) -> Result<Vec<PathBuf>>;
     fn language(&self) -> Self::Language;
+
+    /// Used to configure [OutputSelection] for sparse builds. In certain cases, we might want to
+    /// include some of the file dependencies into the compiler output even if we might not be
+    /// directly interested in them.
+    ///
+    /// Example of such case is when we are compiling Solidity file containing link references and
+    /// need them to be included in the output to deploy needed libraries.
+    ///
+    /// Receives iterator over imports of the current source.
+    ///
+    /// Returns iterator over paths to the files that should be compiled with full output selection.
+    fn compilation_dependencies<'a>(
+        &self,
+        _imported_nodes: impl Iterator<Item = (&'a Path, &'a Self)>,
+    ) -> impl Iterator<Item = &'a Path>
+    where
+        Self: 'a,
+    {
+        vec![].into_iter()
+    }
 }
 
 /// Error returned by compiler. Might also represent a warning or informational message.

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -126,7 +126,7 @@ pub trait CompilerInput: Serialize + Send + Sync + Sized + Debug {
 /// Parser of the source files which is used to identify imports and version requirements of the
 /// given source. Used by path resolver to resolve imports or determine compiler versions needed to
 /// compiler given sources.
-pub trait ParsedSource: Debug + Sized + Send {
+pub trait ParsedSource: Debug + Sized + Send + Clone {
     type Language: Language;
 
     fn parse(content: &str, file: &Path) -> Result<Self>;

--- a/src/compilers/multi.rs
+++ b/src/compilers/multi.rs
@@ -85,6 +85,22 @@ pub enum MultiCompilerParsedSource {
     Vyper(VyperParsedSource),
 }
 
+impl MultiCompilerParsedSource {
+    fn solc(&self) -> Option<&SolData> {
+        match self {
+            Self::Solc(parsed) => Some(parsed),
+            _ => None,
+        }
+    }
+
+    fn vyper(&self) -> Option<&VyperParsedSource> {
+        match self {
+            Self::Vyper(parsed) => Some(parsed),
+            _ => None,
+        }
+    }
+}
+
 /// Compilation error which may occur when compiling Solidity or Vyper sources.
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
@@ -285,6 +301,28 @@ impl ParsedSource for MultiCompilerParsedSource {
             Self::Solc(parsed) => MultiCompilerLanguage::Solc(parsed.language()),
             Self::Vyper(parsed) => MultiCompilerLanguage::Vyper(parsed.language()),
         }
+    }
+
+    fn compilation_dependencies<'a>(
+        &self,
+        imported_nodes: impl Iterator<Item = (&'a Path, &'a Self)>,
+    ) -> impl Iterator<Item = &'a Path>
+    where
+        Self: 'a,
+    {
+        match self {
+            Self::Solc(parsed) => parsed
+                .compilation_dependencies(
+                    imported_nodes.filter_map(|(path, node)| node.solc().map(|node| (path, node))),
+                )
+                .collect::<Vec<_>>(),
+            Self::Vyper(parsed) => parsed
+                .compilation_dependencies(
+                    imported_nodes.filter_map(|(path, node)| node.vyper().map(|node| (path, node))),
+                )
+                .collect::<Vec<_>>(),
+        }
+        .into_iter()
     }
 }
 

--- a/src/compilers/solc.rs
+++ b/src/compilers/solc.rs
@@ -247,6 +247,16 @@ impl ParsedSource for SolData {
             SolcLanguage::Solidity
         }
     }
+
+    fn compilation_dependencies<'a>(
+        &self,
+        imported_nodes: impl Iterator<Item = (&'a Path, &'a Self)>,
+    ) -> impl Iterator<Item = &'a Path>
+    where
+        Self: 'a,
+    {
+        imported_nodes.filter_map(|(path, node)| (!node.libraries.is_empty()).then_some(path))
+    }
 }
 
 impl CompilationError for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ pub mod flatten;
 
 pub mod hh;
 use compilers::{multi::MultiCompiler, Compiler, CompilerSettings};
-pub use filter::SparseOutputFileFilter;
 pub use hh::{HardhatArtifact, HardhatArtifacts};
 
 pub mod resolver;
@@ -111,7 +110,7 @@ pub struct Project<C: Compiler = MultiCompiler, T: ArtifactOutput = Configurable
     pub slash_paths: bool,
     /// Optional sparse output filter used to optimize compilation.
     #[derivative(Debug = "ignore")]
-    pub sparse_output: Option<Box<dyn SparseOutputFileFilter<C::ParsedSource>>>,
+    pub sparse_output: Option<Box<dyn FileFilter>>,
 }
 
 impl Project {
@@ -501,7 +500,7 @@ pub struct ProjectBuilder<C: Compiler = MultiCompiler, T: ArtifactOutput = Confi
     compiler_severity_filter: Severity,
     solc_jobs: Option<usize>,
     /// Optional sparse output filter used to optimize compilation.
-    sparse_output: Option<Box<dyn SparseOutputFileFilter<C::ParsedSource>>>,
+    sparse_output: Option<Box<dyn FileFilter>>,
 }
 
 impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
@@ -650,9 +649,9 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
     }
 
     #[must_use]
-    pub fn sparse_output_filter<F>(mut self, filter: F) -> Self
+    pub fn sparse_output<F>(mut self, filter: F) -> Self
     where
-        F: SparseOutputFileFilter<C::ParsedSource> + 'static,
+        F: FileFilter + 'static,
     {
         self.sparse_output = Some(Box::new(filter));
         self

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -8,7 +8,6 @@ use crate::{
     },
     config::ProjectPathsConfigBuilder,
     error::{Result, SolcError},
-    filter::SparseOutputFileFilter,
     hh::HardhatArtifacts,
     project_util::mock::{MockProjectGenerator, MockProjectSettings},
     remappings::Remapping,
@@ -349,13 +348,6 @@ contract {} {{}}
 
     pub fn compile(&self) -> Result<ProjectCompileOutput<C::CompilationError, T>> {
         self.project().compile()
-    }
-
-    pub fn compile_sparse(
-        &self,
-        filter: Box<dyn SparseOutputFileFilter<C::ParsedSource>>,
-    ) -> Result<ProjectCompileOutput<C::CompilationError, T>> {
-        self.project().compile_sparse(filter)
     }
 
     /// Returns a snapshot of all cached artifacts

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -2476,7 +2476,7 @@ fn can_detect_contract_def_source_files() {
 
 #[test]
 fn can_compile_sparse_with_link_references() {
-    let tmp = TempProject::<MultiCompiler>::dapptools().unwrap();
+    let mut tmp = TempProject::<MultiCompiler>::dapptools().unwrap();
 
     tmp.add_source(
         "ATest.t.sol",
@@ -2504,7 +2504,8 @@ fn can_compile_sparse_with_link_references() {
         )
         .unwrap();
 
-    let mut compiled = tmp.compile_sparse(Box::<TestFileFilter>::default()).unwrap();
+    tmp.project_mut().sparse_output = Some(Box::<TestFileFilter>::default());
+    let mut compiled = tmp.compile().unwrap();
     compiled.assert_success();
 
     let mut output = compiled.clone().into_output();


### PR DESCRIPTION
better approach for https://github.com/foundry-rs/foundry/pull/8061

We already keep all compilation settings on `Project` (paths, compier settings, compiler itself), so this PR moves `sparse_output` to `Project` as well to allow us to just configure it in `Config::project` instead of adding it to compiler on every invocation in multiple places.

Also this PR gets rid of separate `SparseOutputFileFilter<D>` trait and makes `sparse_output` filter just a `FileFilter` again. Instead, we now have `ParsedSource::compilation_dependencies` which determines which of the source imports must be compiled along with it.

Simplified some sparse output related logic along with changes.

Due to `Box<dyn FileFilter>` on `Project` this PR adds `dyn-clone` to keep `Clone` impl and `derivative` to avoid manually implementing `Debug`