### PR TITLE
fix: small sparse output updates

### DIFF
--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -501,6 +501,13 @@ impl<L: Language> FilteredCompilerSources<L> {
 
         for (input, mut output, actually_dirty) in results {
             let version = input.version();
+
+            output.retain_files(
+                actually_dirty
+                    .iter()
+                    .map(|f| f.strip_prefix(project.paths.root.as_path()).unwrap_or(f)),
+            );
+
             // if configured also create the build info
             if project.build_info {
                 let build_info = RawBuildInfo::new(&input, &output, version)?;
@@ -508,7 +515,6 @@ impl<L: Language> FilteredCompilerSources<L> {
             }
 
             output.join_all(project.paths.root.as_path());
-            output.retain_files(actually_dirty);
 
             aggregated.extend(version.clone(), output);
         }

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -138,7 +138,10 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
     ///
     /// Multiple (`Solc` -> `Sources`) pairs can be compiled in parallel if the `Project` allows
     /// multiple `jobs`, see [`crate::Project::set_solc_jobs()`].
-    pub fn with_sources(project: &'a Project<C, T>, sources: Sources) -> Result<Self> {
+    pub fn with_sources(project: &'a Project<C, T>, mut sources: Sources) -> Result<Self> {
+        if let Some(filter) = &project.sparse_output {
+            sources.retain(|f, _| filter.is_match(f))
+        }
         let graph = Graph::resolve_sources(&project.paths, sources)?;
         let (sources, edges) = graph.into_sources_by_version(
             project.offline,
@@ -460,16 +463,11 @@ impl<L: Language> FilteredCompilerSources<L> {
                     continue;
                 }
 
-                let dirty_files: Vec<PathBuf> = filtered_sources.dirty_files().cloned().collect();
-
                 // depending on the composition of the filtered sources, the output selection can be
                 // optimized
                 let mut opt_settings = project.settings.clone();
-                let sources =
+                let (sources, actually_dirty) =
                     sparse_output.sparse_sources(filtered_sources, &mut opt_settings, graph);
-
-                let actually_dirty =
-                    sources.keys().filter(|f| dirty_files.contains(f)).cloned().collect::<Vec<_>>();
 
                 if actually_dirty.is_empty() {
                     // nothing to compile for this particular language, all dirty files are in the
@@ -501,7 +499,7 @@ impl<L: Language> FilteredCompilerSources<L> {
 
         let mut aggregated = AggregatedCompilerOutput::default();
 
-        for (input, mut output) in results {
+        for (input, mut output, actually_dirty) in results {
             let version = input.version();
             // if configured also create the build info
             if project.build_info {
@@ -510,6 +508,7 @@ impl<L: Language> FilteredCompilerSources<L> {
             }
 
             output.join_all(project.paths.root.as_path());
+            output.retain_files(actually_dirty);
 
             aggregated.extend(version.clone(), output);
         }
@@ -538,7 +537,7 @@ impl<L: Language> FilteredCompilerSources<L> {
 fn compile_sequential<C: Compiler<Input = I>, I: CompilerInput>(
     compiler: &C,
     jobs: Vec<(I, Vec<PathBuf>)>,
-) -> Result<Vec<(I, CompilerOutput<C::CompilationError>)>> {
+) -> Result<Vec<(I, CompilerOutput<C::CompilationError>, Vec<PathBuf>)>> {
     jobs.into_iter()
         .map(|(input, actually_dirty)| {
             let start = Instant::now();
@@ -550,7 +549,7 @@ fn compile_sequential<C: Compiler<Input = I>, I: CompilerInput>(
             let output = compiler.compile(&input)?;
             report::compiler_success(&input.compiler_name(), input.version(), &start.elapsed());
 
-            Ok((input, output))
+            Ok((input, output, actually_dirty))
         })
         .collect()
 }
@@ -560,7 +559,7 @@ fn compile_parallel<C: Compiler<Input = I>, I: CompilerInput>(
     compiler: &C,
     jobs: Vec<(I, Vec<PathBuf>)>,
     num_jobs: usize,
-) -> Result<Vec<(I, CompilerOutput<C::CompilationError>)>> {
+) -> Result<Vec<(I, CompilerOutput<C::CompilationError>, Vec<PathBuf>)>> {
     // need to get the currently installed reporter before installing the pool, otherwise each new
     // thread in the pool will get initialized with the default value of the `thread_local!`'s
     // localkey. This way we keep access to the reporter in the rayon pool
@@ -587,7 +586,7 @@ fn compile_parallel<C: Compiler<Input = I>, I: CompilerInput>(
                         input.version(),
                         &start.elapsed(),
                     );
-                    (input, output)
+                    (input, output, actually_dirty)
                 })
             })
             .collect()

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -180,7 +180,7 @@ impl<E> CompilerOutput<E> {
     /// Retains only those files the given iterator yields
     ///
     /// In other words, removes all contracts for files not included in the iterator
-    pub fn retain_files<'a, F, I>(&mut self, files: I)
+    pub fn retain_files<F, I>(&mut self, files: I)
     where
         F: AsRef<Path>,
         I: IntoIterator<Item = F>,

--- a/src/compilers/mod.rs
+++ b/src/compilers/mod.rs
@@ -180,14 +180,15 @@ impl<E> CompilerOutput<E> {
     /// Retains only those files the given iterator yields
     ///
     /// In other words, removes all contracts for files not included in the iterator
-    pub fn retain_files<'a, I>(&mut self, files: I)
+    pub fn retain_files<'a, F, I>(&mut self, files: I)
     where
-        I: IntoIterator<Item = &'a Path>,
+        F: AsRef<Path>,
+        I: IntoIterator<Item = F>,
     {
         // Note: use `to_lowercase` here because solc not necessarily emits the exact file name,
         // e.g. `src/utils/upgradeProxy.sol` is emitted as `src/utils/UpgradeProxy.sol`
         let files: HashSet<_> =
-            files.into_iter().map(|s| s.to_string_lossy().to_lowercase()).collect();
+            files.into_iter().map(|s| s.as_ref().to_string_lossy().to_lowercase()).collect();
         self.contracts.retain(|f, _| files.contains(&f.to_string_lossy().to_lowercase()));
         self.sources.retain(|f, _| files.contains(&f.to_string_lossy().to_lowercase()));
     }

--- a/src/compilers/vyper/output.rs
+++ b/src/compilers/vyper/output.rs
@@ -9,11 +9,14 @@ use std::{
 };
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Bytecode {
     pub object: Bytes,
     /// Opcodes list (string)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opcodes: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_vyper_sourcemap")]
+    pub source_map: Option<String>,
 }
 
 impl From<Bytecode> for crate::artifacts::Bytecode {
@@ -21,28 +24,10 @@ impl From<Bytecode> for crate::artifacts::Bytecode {
         crate::artifacts::Bytecode {
             object: BytecodeObject::Bytecode(bytecode.object),
             opcodes: bytecode.opcodes,
+            source_map: bytecode.source_map,
             function_debug_data: Default::default(),
             generated_sources: Default::default(),
-            source_map: Default::default(),
             link_references: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DeployedBytecode {
-    #[serde(flatten)]
-    pub bytecode: Option<Bytecode>,
-    #[serde(default, deserialize_with = "deserialize_vyper_sourcemap")]
-    pub source_map: Option<String>,
-}
-
-impl From<DeployedBytecode> for crate::artifacts::DeployedBytecode {
-    fn from(deployed_bytecode: DeployedBytecode) -> Self {
-        crate::artifacts::DeployedBytecode {
-            bytecode: deployed_bytecode.bytecode.map(Into::into),
-            immutable_references: Default::default(),
         }
     }
 }
@@ -53,7 +38,7 @@ pub struct VyperEvm {
     #[serde(default)]
     pub bytecode: Option<Bytecode>,
     #[serde(default)]
-    pub deployed_bytecode: Option<DeployedBytecode>,
+    pub deployed_bytecode: Option<Bytecode>,
     /// The list of function hashes
     #[serde(default)]
     pub method_identifiers: BTreeMap<String, String>,
@@ -63,7 +48,10 @@ impl From<VyperEvm> for Evm {
     fn from(evm: VyperEvm) -> Self {
         Evm {
             bytecode: evm.bytecode.map(Into::into),
-            deployed_bytecode: evm.deployed_bytecode.map(Into::into),
+            deployed_bytecode: evm.deployed_bytecode.map(|b| crate::artifacts::DeployedBytecode {
+                bytecode: Some(b.into()),
+                immutable_references: Default::default(),
+            }),
             method_identifiers: evm.method_identifiers,
             assembly: None,
             legacy_assembly: None,

--- a/src/compilers/vyper/settings.rs
+++ b/src/compilers/vyper/settings.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Clone, Copy, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum VyperOptimizationMode {
     Gas,
     Codesize,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -132,7 +132,6 @@ impl<'a> SparseOutputFilter<'a> {
 
                             PathBuf::from(import.to_slash_lossy().to_string())
                         };
-                        
 
                         required_sources.push(import);
                     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -124,7 +124,17 @@ impl<'a> SparseOutputFilter<'a> {
                         graph.get_parsed_source(import).map(|data| (import.as_path(), data))
                     });
                     for import in data.compilation_dependencies(imports) {
-                        required_sources.push(import.to_path_buf());
+                        let import = import.to_path_buf();
+
+                        #[cfg(windows)]
+                        let import = {
+                            use path_slash::PathBufExt;
+
+                            PathBuf::from(import.to_slash_lossy().to_string())
+                        };
+                        
+
+                        required_sources.push(import);
                     }
                 }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -46,6 +46,11 @@ pub static VYPER: Lazy<Vyper> = Lazy::new(|| {
         use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
         take_solc_installer_lock!(_lock);
+        let path = std::env::temp_dir().join("vyper");
+
+        if path.exists() {
+            return Vyper::new(path).unwrap();
+        }
 
         let url = match platform() {
             Platform::MacOsAarch64 => "https://github.com/vyperlang/vyper/releases/download/v0.3.10/vyper.0.3.10+commit.91361694.darwin",
@@ -59,7 +64,6 @@ pub static VYPER: Lazy<Vyper> = Lazy::new(|| {
         assert!(res.status().is_success());
 
         let bytes = res.bytes().await.unwrap();
-        let path = std::env::temp_dir().join("vyper");
 
         std::fs::write(&path, bytes).unwrap();
 


### PR DESCRIPTION
Ensure that input and output only contains sources filtered out by sparse output filter, if present. This is needed to avoid optimized artifacts without abi and bytecode ending up in cache.