### PR TITLE
fix: better tracking of cache entries

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -996,6 +996,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
         Ok(cached_artifacts)
     }
 
+    /// Marks the cached entry as seen by the compiler, if it's cached.
     pub fn compiler_seen(&mut self, file: &Path) {
         if let ArtifactsCache::Cached(cache) = self {
             if let Some(entry) = cache.cache.entry_mut(file) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -387,6 +387,14 @@ pub struct CacheEntry<S = Settings> {
     /// This map tracks the artifacts by `name -> (Version -> PathBuf)`.
     /// This mimics the default artifacts directory structure
     pub artifacts: BTreeMap<String, BTreeMap<Version, PathBuf>>,
+    /// Whether this file was compiled at least once.
+    ///
+    /// If this is true and `artifacts` are empty, it means that given version of the file does
+    /// not produce any artifacts and it should not be compiled again.
+    ///
+    /// If this is false, then artifacts are definitely empty and it should be compiled if we may
+    /// need artifacts.
+    pub seen_by_compiler: bool,
 }
 
 impl<S> CacheEntry<S> {
@@ -588,6 +596,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
             version_requirement: self.edges.version_requirement(&file).map(|v| v.to_string()),
             // artifacts remain empty until we received the compiler output
             artifacts: Default::default(),
+            seen_by_compiler: false,
         };
 
         self.cache.files.insert(file, entry.clone());
@@ -658,7 +667,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
         // only check artifact's existence if the file generated artifacts.
         // e.g. a solidity file consisting only of import statements (like interfaces that
         // re-export) do not create artifacts
-        if entry.artifacts.is_empty() {
+        if entry.seen_by_compiler && entry.artifacts.is_empty() {
             trace!("no artifacts");
             return false;
         }
@@ -985,5 +994,13 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
         }
 
         Ok(cached_artifacts)
+    }
+
+    pub fn compiler_seen(&mut self, file: &Path) {
+        if let ArtifactsCache::Cached(cache) = self {
+            if let Some(entry) = cache.cache.entry_mut(file) {
+                entry.seen_by_compiler = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, during sparse compilation (and probably in some other cases) we might end up in a situation when cache contains empty entries which can actually produce artifacts when compied.

For example, if A.sol imports B.sol and sparse filter tells us to only compile A.sol, then B.sol will appear in cache (because we have to track its source hash to invalidate A.sol's cache), however, we will erase its output selection when invoking solc, so it will not have any artifacts.

Thus, if compiler is invoked later without sparse filter, it will simply skip compiling B.sol because it will assume that it just does not contain any contract definitions: https://github.com/foundry-rs/compilers/blob/4cf78434b21481c78a8236c95ac82eb945a01758/src/cache.rs#L658-L663

Because of that, artifact for B.sol will be missing until the cache is cleared.

The issue is basically that we might have two situations:
- Entry does not contain artifacts because it does not produce them when compiled
- Entry does not contain artifacts because we've never tried to compile it

This PR adds `seenByCompiler` flag which is set to false by default for all newly created entries and switched when entries are compiled as dirty files (without pruned output selection). 