### PR TITLE
fix: always fix windows line endings

### DIFF
--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -1451,7 +1451,6 @@ impl Source {
         let content = fs::read_to_string(file).map_err(|err| SolcIoError::new(err, file))?;
 
         // Normalize line endings to ensure deterministic metadata.
-        #[cfg(windows)]
         let content = content.replace("\r\n", "\n");
 
         Ok(Self::new(content))

--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -1448,10 +1448,12 @@ impl Source {
     pub fn read(file: impl AsRef<Path>) -> Result<Self, SolcIoError> {
         let file = file.as_ref();
         trace!(file=%file.display());
-        let content = fs::read_to_string(file).map_err(|err| SolcIoError::new(err, file))?;
+        let mut content = fs::read_to_string(file).map_err(|err| SolcIoError::new(err, file))?;
 
         // Normalize line endings to ensure deterministic metadata.
-        let content = content.replace("\r\n", "\n");
+        if content.contains('\r') {
+            content = content.replace("\r\n", "\n");
+        }
 
         Ok(Self::new(content))
     }
@@ -1527,11 +1529,13 @@ impl Source {
     /// async version of `Self::read`
     pub async fn async_read(file: impl AsRef<Path>) -> Result<Self, SolcIoError> {
         let file = file.as_ref();
-        let content =
+        let mut content =
             tokio::fs::read_to_string(file).await.map_err(|err| SolcIoError::new(err, file))?;
 
         // Normalize line endings to ensure deterministic metadata.
-        let content = content.replace("\r\n", "\n");
+        if content.contains('\r') {
+            content = content.replace("\r\n", "\n");
+        }
 
         Ok(Self::new(content))
     }

--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -1531,7 +1531,6 @@ impl Source {
             tokio::fs::read_to_string(file).await.map_err(|err| SolcIoError::new(err, file))?;
 
         // Normalize line endings to ensure deterministic metadata.
-        #[cfg(windows)]
         let content = content.replace("\r\n", "\n");
 
         Ok(Self::new(content))


### PR DESCRIPTION
Follow-up to https://github.com/foundry-rs/compilers/pull/108.

It seems that in certain cases files on WSL still have `\r\n` prefix, thus this PR changes logic to always fix Windows line endings and not only on Windows builds.