### PR TITLE
feat: track and cache context of each compiler invocation

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,7 @@ allow = [
     # https://github.com/briansmith/webpki/issues/148
     "LicenseRef-webpki",
     "BSL-1.0",
+    "Unicode-3.0",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses

--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -1981,7 +1981,14 @@ impl SourceFiles {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::AggregatedCompilerOutput;
+    use crate::{
+        buildinfo::RawBuildInfo,
+        compilers::{
+            solc::{SolcCompiler, SolcVersionedInput},
+            CompilerInput,
+        },
+        AggregatedCompilerOutput,
+    };
     use alloy_primitives::Address;
 
     #[test]
@@ -2014,8 +2021,16 @@ mod tests {
             sources: Default::default(),
         };
 
-        let mut aggregated = AggregatedCompilerOutput::default();
-        aggregated.extend("0.8.12".parse().unwrap(), out_converted);
+        let v: Version = "0.8.12".parse().unwrap();
+        let input = SolcVersionedInput::build(
+            Default::default(),
+            Default::default(),
+            SolcLanguage::Solidity,
+            v.clone(),
+        );
+        let build_info = RawBuildInfo::new(&input, &out_converted).unwrap();
+        let mut aggregated = AggregatedCompilerOutput::<SolcCompiler>::default();
+        aggregated.extend(v, build_info, out_converted);
         assert!(!aggregated.is_unchanged());
     }
 

--- a/src/artifacts/mod.rs
+++ b/src/artifacts/mod.rs
@@ -2028,7 +2028,7 @@ mod tests {
             SolcLanguage::Solidity,
             v.clone(),
         );
-        let build_info = RawBuildInfo::new(&input, &out_converted).unwrap();
+        let build_info = RawBuildInfo::new(&input, &out_converted, true).unwrap();
         let mut aggregated = AggregatedCompilerOutput::<SolcCompiler>::default();
         aggregated.extend(v, build_info, out_converted);
         assert!(!aggregated.is_unchanged());

--- a/src/buildinfo.rs
+++ b/src/buildinfo.rs
@@ -67,6 +67,11 @@ impl<L: Language> BuildContext<L> {
             *path = root.as_ref().join(path.as_path());
         });
     }
+
+    pub fn with_joined_paths(mut self, root: impl AsRef<Path>) -> Self {
+        self.join_all(root);
+        self
+    }
 }
 
 /// Represents `BuildInfo` object
@@ -121,12 +126,6 @@ impl<L: Language> RawBuildInfo<L> {
         }
 
         Ok(RawBuildInfo { id, build_info, build_context })
-    }
-
-    // We only join [BuildContext] paths here because input and output are kept in the same format
-    // as compiler seen/produced them.
-    pub fn join_all(&mut self, root: impl AsRef<Path>) {
-        self.build_context.join_all(root);
     }
 }
 

--- a/src/buildinfo.rs
+++ b/src/buildinfo.rs
@@ -10,10 +10,8 @@ use md5::Digest;
 use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    rc::Rc,
 };
 
 pub const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-build-info-1";
@@ -101,7 +99,7 @@ impl<L: Language> RawBuildInfo<L> {
 
         let solc_short = format!("{}.{}.{}", version.major, version.minor, version.patch);
         hasher.update(&solc_short);
-        hasher.update(&version.to_string());
+        hasher.update(version.to_string());
 
         let input = serde_json::to_value(input)?;
         hasher.update(&serde_json::to_string(&input)?);
@@ -115,11 +113,11 @@ impl<L: Language> RawBuildInfo<L> {
         let mut build_info = BTreeMap::new();
 
         if full_build_info {
-            build_info.insert("_format".to_string(), serde_json::to_value(&ETHERS_FORMAT_VERSION)?);
+            build_info.insert("_format".to_string(), serde_json::to_value(ETHERS_FORMAT_VERSION)?);
             build_info.insert("solcVersion".to_string(), serde_json::to_value(&solc_short)?);
             build_info.insert("solcLongVersion".to_string(), serde_json::to_value(&version)?);
             build_info.insert("input".to_string(), input);
-            build_info.insert("output".to_string(), serde_json::to_value(&output)?);
+            build_info.insert("output".to_string(), serde_json::to_value(output)?);
         }
 
         Ok(RawBuildInfo { id, build_info, build_context })
@@ -129,21 +127,6 @@ impl<L: Language> RawBuildInfo<L> {
     // as compiler seen/produced them.
     pub fn join_all(&mut self, root: impl AsRef<Path>) {
         self.build_context.join_all(root);
-    }
-}
-
-#[derive(Clone)]
-struct BuildInfoWriter {
-    buf: Rc<RefCell<Vec<u8>>>,
-}
-
-impl std::io::Write for BuildInfoWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buf.borrow_mut().write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.buf.borrow_mut().flush()
     }
 }
 

--- a/src/buildinfo.rs
+++ b/src/buildinfo.rs
@@ -41,7 +41,9 @@ impl<I: DeserializeOwned, O: DeserializeOwned> BuildInfo<I, O> {
 /// Additional context we cache for each compiler run.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct BuildContext<L> {
+    /// Mapping from internal compiler source id to path of the source file.
     pub source_id_to_path: HashMap<u32, PathBuf>,
+    /// Language of the compiler.
     pub language: L,
 }
 

--- a/src/buildinfo.rs
+++ b/src/buildinfo.rs
@@ -10,7 +10,7 @@ use md5::Digest;
 use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -40,7 +40,7 @@ impl<I: DeserializeOwned, O: DeserializeOwned> BuildInfo<I, O> {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct BuildContext<L> {
     /// Mapping from internal compiler source id to path of the source file.
-    pub source_id_to_path: HashMap<u32, PathBuf>,
+    pub source_id_to_path: BTreeMap<u32, PathBuf>,
     /// Language of the compiler.
     pub language: L,
 }
@@ -50,7 +50,7 @@ impl<L: Language> BuildContext<L> {
     where
         I: CompilerInput<Language = L>,
     {
-        let mut source_id_to_path = HashMap::new();
+        let mut source_id_to_path = BTreeMap::new();
 
         let input_sources = input.sources().map(|(path, _)| path).collect::<HashSet<_>>();
         for (path, source) in output.sources.iter() {

--- a/src/buildinfo.rs
+++ b/src/buildinfo.rs
@@ -1,11 +1,20 @@
 //! Represents an entire build
 
-use crate::{utils, SolcError};
+use crate::{
+    compilers::{CompilationError, CompilerInput, CompilerOutput, Language},
+    error::Result,
+    utils,
+};
 use alloy_primitives::hex;
 use md5::Digest;
 use semver::Version;
-use serde::{de::DeserializeOwned, ser::SerializeStruct, Deserialize, Serialize, Serializer};
-use std::{cell::RefCell, path::Path, rc::Rc};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet},
+    path::{Path, PathBuf},
+    rc::Rc,
+};
 
 pub const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-build-info-1";
 
@@ -24,59 +33,97 @@ pub struct BuildInfo<I, O> {
 
 impl<I: DeserializeOwned, O: DeserializeOwned> BuildInfo<I, O> {
     /// Deserializes the `BuildInfo` object from the given file
-    pub fn read(path: impl AsRef<Path>) -> Result<Self, SolcError> {
+    pub fn read(path: impl AsRef<Path>) -> Result<Self> {
         utils::read_json_file(path)
+    }
+}
+
+/// Additional context we cache for each compiler run.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct BuildContext<L> {
+    pub source_id_to_path: HashMap<u32, PathBuf>,
+    pub language: L,
+}
+
+impl<L: Language> BuildContext<L> {
+    pub fn new<I, E>(input: &I, output: &CompilerOutput<E>) -> Result<Self>
+    where
+        I: CompilerInput<Language = L>,
+    {
+        let mut source_id_to_path = HashMap::new();
+
+        let input_sources = input.sources().map(|(path, _)| path).collect::<HashSet<_>>();
+        for (path, source) in output.sources.iter() {
+            if input_sources.contains(path.as_path()) {
+                source_id_to_path.insert(source.id, path.to_path_buf());
+            }
+        }
+
+        Ok(Self { source_id_to_path, language: input.language() })
+    }
+
+    pub fn join_all(&mut self, root: impl AsRef<Path>) {
+        self.source_id_to_path.values_mut().for_each(|path| {
+            *path = root.as_ref().join(path.as_path());
+        });
     }
 }
 
 /// Represents `BuildInfo` object
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct RawBuildInfo {
+pub struct RawBuildInfo<L> {
     /// The hash that identifies the BuildInfo
     pub id: String,
+    #[serde(flatten)]
+    pub build_context: BuildContext<L>,
     /// serialized `BuildInfo` json
-    pub build_info: String,
+    #[serde(flatten)]
+    pub build_info: BTreeMap<String, serde_json::Value>,
 }
 
 // === impl RawBuildInfo ===
 
-impl RawBuildInfo {
+impl<L: Language> RawBuildInfo<L> {
     /// Serializes a `BuildInfo` object
-    pub fn new<I: Serialize, O: Serialize>(
+    pub fn new<I: CompilerInput<Language = L>, E: CompilationError>(
         input: &I,
-        output: &O,
-        version: &Version,
-    ) -> serde_json::Result<RawBuildInfo> {
+        output: &CompilerOutput<E>,
+    ) -> Result<RawBuildInfo<L>> {
+        let version = input.version().clone();
+        let build_context = BuildContext::new(input, output)?;
+
         let mut hasher = md5::Md5::new();
-        let w = BuildInfoWriter { buf: Rc::new(RefCell::new(Vec::with_capacity(128))) };
-        let mut buf = w.clone();
-        let mut serializer = serde_json::Serializer::pretty(&mut buf);
-        let mut s = serializer.serialize_struct("BuildInfo", 6)?;
-        s.serialize_field("_format", &ETHERS_FORMAT_VERSION)?;
+        let mut build_info = BTreeMap::new();
+
+        build_info.insert("_format".to_string(), serde_json::to_value(&ETHERS_FORMAT_VERSION)?);
+        hasher.update(ETHERS_FORMAT_VERSION);
+
         let solc_short = format!("{}.{}.{}", version.major, version.minor, version.patch);
-        s.serialize_field("solcVersion", &solc_short)?;
-        s.serialize_field("solcLongVersion", &version)?;
-        s.serialize_field("input", input)?;
+        build_info.insert("solcVersion".to_string(), serde_json::to_value(&solc_short)?);
+        hasher.update(&solc_short);
+
+        build_info.insert("solcLongVersion".to_string(), serde_json::to_value(&version)?);
+        hasher.update(&version.to_string());
+
+        let input = serde_json::to_value(input)?;
+        hasher.update(&serde_json::to_string(&input)?);
+        build_info.insert("input".to_string(), input);
 
         // create the hash for `{_format,solcVersion,solcLongVersion,input}`
         // N.B. this is not exactly the same as hashing the json representation of these values but
         // the must efficient one
-        hasher.update(&*w.buf.borrow());
         let result = hasher.finalize();
         let id = hex::encode(result);
 
-        s.serialize_field("id", &id)?;
-        s.serialize_field("output", output)?;
-        s.end()?;
+        build_info.insert("output".to_string(), serde_json::to_value(&output)?);
 
-        drop(buf);
+        Ok(RawBuildInfo { id, build_info, build_context })
+    }
 
-        let build_info = unsafe {
-            // serde_json does not emit non UTF8
-            String::from_utf8_unchecked(w.buf.take())
-        };
-
-        Ok(RawBuildInfo { id, build_info })
+    // We only join [BuildContext] paths here because input and output are kept in the same format
+    // as compiler seen/produced them.
+    pub fn join_all(&mut self, root: impl AsRef<Path>) {
+        self.build_context.join_all(root);
     }
 }
 
@@ -98,19 +145,28 @@ impl std::io::Write for BuildInfoWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{artifacts::Error, compilers::CompilerOutput, SolcInput, Source};
+    use crate::{
+        artifacts::Error,
+        compilers::{
+            solc::{SolcLanguage, SolcVersionedInput},
+            CompilerOutput,
+        },
+        Source,
+    };
     use std::{collections::BTreeMap, path::PathBuf};
 
     #[test]
     fn build_info_serde() {
-        let inputs = SolcInput::resolve_and_build(
+        let v: Version = "0.8.4+commit.c7e474f2".parse().unwrap();
+        let input = SolcVersionedInput::build(
             BTreeMap::from([(PathBuf::from("input.sol"), Source::new(""))]),
             Default::default(),
+            SolcLanguage::Solidity,
+            v,
         );
         let output = CompilerOutput::<Error>::default();
-        let v: Version = "0.8.4+commit.c7e474f2".parse().unwrap();
-        let raw_info = RawBuildInfo::new(&inputs[0], &output, &v).unwrap();
-        let _info: BuildInfo<SolcInput, CompilerOutput<Error>> =
-            serde_json::from_str(&raw_info.build_info).unwrap();
+        let raw_info = RawBuildInfo::new(&input, &output).unwrap();
+        let _info: BuildInfo<SolcVersionedInput, CompilerOutput<Error>> =
+            serde_json::from_str(&serde_json::to_string(&raw_info).unwrap()).unwrap();
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -320,14 +320,14 @@ impl<S: CompilerSettings> CompilerCache<S> {
         use rayon::prelude::*;
 
         let build_info_dir = build_info_dir.as_ref();
-
         self.builds
             .par_iter()
             .map(|build_id| {
                 utils::read_json_file(build_info_dir.join(build_id).with_extension("json"))
                     .map(|b| (build_id.clone(), b))
             })
-            .collect()
+            .collect::<Result<_>>()
+            .map(|b| Builds(b))
     }
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -377,9 +377,12 @@ impl<'a, S: CompilerSettings> From<&'a ProjectPathsConfig> for CompilerCache<S> 
     }
 }
 
+/// Cached artifact data.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CachedArtifact {
+    /// Path to the artifact file.
     pub path: PathBuf,
+    /// Build id which produced the given artifact.
     pub build_id: String,
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -314,6 +314,8 @@ impl<S: CompilerSettings> CompilerCache<S> {
 
     /// Reads all cached [BuildContext]s from disk. [BuildContext] is inlined into [RawBuildInfo]
     /// objects, so we are basically just partially deserializing build infos here.
+    ///
+    /// [BuildContext]: crate::buildinfo::BuildContext
     pub fn read_builds<L: Language>(&self, build_info_dir: impl AsRef<Path>) -> Result<Builds<L>> {
         use rayon::prelude::*;
 

--- a/src/compile/output/contracts.rs
+++ b/src/compile/output/contracts.rs
@@ -284,6 +284,7 @@ impl IntoIterator for VersionedContracts {
 pub struct VersionedContract {
     pub contract: Contract,
     pub version: Version,
+    pub build_id: String,
 }
 
 /// A mapping of `ArtifactId` and their `CompactContractBytecode`

--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -14,11 +14,12 @@ use crate::{
 };
 use contracts::{VersionedContract, VersionedContracts};
 use semver::Version;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::BTreeMap,
     fmt,
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
 use yansi::Paint;
@@ -28,7 +29,38 @@ pub mod info;
 pub mod sources;
 
 /// A mapping from build_id to [BuildContext].
-pub type Builds<L> = BTreeMap<String, BuildContext<L>>;
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct Builds<L>(pub BTreeMap<String, BuildContext<L>>);
+
+impl<L> Default for Builds<L> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<L> Deref for Builds<L> {
+    type Target = BTreeMap<String, BuildContext<L>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<L> DerefMut for Builds<L> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<L> IntoIterator for Builds<L> {
+    type Item = (String, BuildContext<L>);
+    type IntoIter = std::collections::btree_map::IntoIter<String, BuildContext<L>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
 
 /// Contains a mixture of already compiled/cached artifacts and the input set of sources that still
 /// need to be compiled.

--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -27,6 +27,7 @@ pub mod contracts;
 pub mod info;
 pub mod sources;
 
+/// A mapping from build_id to [BuildContext].
 pub type Builds<L> = BTreeMap<String, BuildContext<L>>;
 
 /// Contains a mixture of already compiled/cached artifacts and the input set of sources that still

--- a/src/compile/output/mod.rs
+++ b/src/compile/output/mod.rs
@@ -27,6 +27,8 @@ pub mod contracts;
 pub mod info;
 pub mod sources;
 
+pub type Builds<L> = BTreeMap<String, BuildContext<L>>;
+
 /// Contains a mixture of already compiled/cached artifacts and the input set of sources that still
 /// need to be compiled.
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -47,7 +49,7 @@ pub struct ProjectCompileOutput<
     /// set minimum level of severity that is treated as an error
     pub(crate) compiler_severity_filter: Severity,
     /// all build infos that were just compiled
-    pub(crate) builds: BTreeMap<String, BuildContext<C::Language>>,
+    pub(crate) builds: Builds<C::Language>,
 }
 
 impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {

--- a/src/compile/output/sources.rs
+++ b/src/compile/output/sources.rs
@@ -240,4 +240,5 @@ impl IntoIterator for VersionedSourceFiles {
 pub struct VersionedSourceFile {
     pub source_file: SourceFile,
     pub version: Version,
+    pub build_id: String,
 }

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -489,12 +489,11 @@ impl<L: Language> FilteredCompilerSources<L> {
 
                 trace!("calling {} with {} sources {:?}", version, sources.len(), sources.keys());
 
-                let mut input =
-                    C::Input::build(sources, opt_settings, language.clone(), version.clone())
-                        .with_base_path(project.paths.root.clone())
-                        .with_allow_paths(project.paths.allowed_paths.clone())
-                        .with_include_paths(include_paths.clone())
-                        .with_remappings(project.paths.remappings.clone());
+                let mut input = C::Input::build(sources, opt_settings, language, version.clone())
+                    .with_base_path(project.paths.root.clone())
+                    .with_allow_paths(project.paths.allowed_paths.clone())
+                    .with_include_paths(include_paths.clone())
+                    .with_remappings(project.paths.remappings.clone());
 
                 input.strip_prefix(project.paths.root.as_path());
 

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -339,6 +339,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsState<'a, T, C> {
                 .iter()
                 .map(|build_info| (build_info.id.clone(), build_info.build_context.clone()))
                 .chain(cached_builds)
+                .map(|(id, context)| (id, context.with_joined_paths(project.paths.root.as_path())))
                 .collect(),
         );
 
@@ -519,15 +520,13 @@ impl<L: Language> FilteredCompilerSources<L> {
                 cache.compiler_seen(file);
             }
 
-            let mut build_info = RawBuildInfo::new(&input, &output, project.build_info)?;
+            let build_info = RawBuildInfo::new(&input, &output, project.build_info)?;
 
             output.retain_files(
                 actually_dirty
                     .iter()
                     .map(|f| f.strip_prefix(project.paths.root.as_path()).unwrap_or(f)),
             );
-
-            build_info.join_all(project.paths.root.as_path());
             output.join_all(project.paths.root.as_path());
 
             aggregated.extend(version.clone(), build_info, output);

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -108,7 +108,7 @@ use crate::{
     compilers::{Compiler, CompilerInput, CompilerOutput, Language},
     error::Result,
     filter::SparseOutputFilter,
-    output::AggregatedCompilerOutput,
+    output::{AggregatedCompilerOutput, Builds},
     report,
     resolver::GraphEdges,
     ArtifactOutput, Graph, Project, ProjectCompileOutput, Sources,
@@ -333,12 +333,14 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsState<'a, T, C> {
 
         project.artifacts_handler().handle_cached_artifacts(&cached_artifacts)?;
 
-        let builds = output
-            .build_infos
-            .iter()
-            .map(|build_info| (build_info.id.clone(), build_info.build_context.clone()))
-            .chain(cached_builds)
-            .collect();
+        let builds = Builds(
+            output
+                .build_infos
+                .iter()
+                .map(|build_info| (build_info.id.clone(), build_info.build_context.clone()))
+                .chain(cached_builds)
+                .collect(),
+        );
 
         Ok(ProjectCompileOutput {
             compiler_output: output,

--- a/src/compile/project.rs
+++ b/src/compile/project.rs
@@ -518,7 +518,7 @@ impl<L: Language> FilteredCompilerSources<L> {
                 cache.compiler_seen(file);
             }
 
-            let mut build_info = RawBuildInfo::new(&input, &output)?;
+            let mut build_info = RawBuildInfo::new(&input, &output, project.build_info)?;
 
             output.retain_files(
                 actually_dirty

--- a/src/compilers/solc.rs
+++ b/src/compilers/solc.rs
@@ -6,7 +6,8 @@ use super::{
 };
 use crate::{
     artifacts::{
-        output_selection::OutputSelection, Error, Settings as SolcSettings, SolcInput, Sources,
+        output_selection::OutputSelection, Error, Settings as SolcSettings, SolcInput, Source,
+        Sources,
     },
     error::Result,
     remappings::Remapping,
@@ -33,7 +34,7 @@ pub enum SolcCompiler {
 }
 
 /// Languages supported by the Solc compiler.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum SolcLanguage {
     Solidity,
@@ -116,17 +117,14 @@ impl Compiler for SolcCompiler {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SolcVersionedInput {
-    #[serde(skip)]
     pub version: Version,
     #[serde(flatten)]
     pub input: SolcInput,
-    #[serde(skip)]
     pub allow_paths: BTreeSet<PathBuf>,
-    #[serde(skip)]
     pub base_path: Option<PathBuf>,
-    #[serde(skip)]
     pub include_paths: BTreeSet<PathBuf>,
 }
 
@@ -161,6 +159,10 @@ impl CompilerInput for SolcVersionedInput {
 
     fn version(&self) -> &Version {
         &self.version
+    }
+
+    fn sources(&self) -> impl Iterator<Item = (&Path, &Source)> {
+        self.input.sources.iter().map(|(path, source)| (path.as_path(), source))
     }
 
     fn with_remappings(mut self, remappings: Vec<Remapping>) -> Self {

--- a/src/compilers/solc.rs
+++ b/src/compilers/solc.rs
@@ -154,7 +154,7 @@ impl CompilerInput for SolcVersionedInput {
     }
 
     fn language(&self) -> Self::Language {
-        self.input.language.clone()
+        self.input.language
     }
 
     fn version(&self) -> &Version {

--- a/src/compilers/vyper/error.rs
+++ b/src/compilers/vyper/error.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct VyperSourceLocation {
     file: PathBuf,
     #[serde(rename = "lineno")]
@@ -16,7 +16,7 @@ pub struct VyperSourceLocation {
     offset: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VyperCompilationError {
     pub message: String,

--- a/src/compilers/vyper/input.rs
+++ b/src/compilers/vyper/input.rs
@@ -1,7 +1,10 @@
 use std::{borrow::Cow, path::Path};
 
 use super::{settings::VyperSettings, VyperLanguage, VYPER_INTERFACE_EXTENSION};
-use crate::{artifacts::Sources, compilers::CompilerInput};
+use crate::{
+    artifacts::{Source, Sources},
+    compilers::CompilerInput,
+};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
@@ -82,5 +85,13 @@ impl CompilerInput for VyperVersionedInput {
 
     fn version(&self) -> &Version {
         &self.version
+    }
+
+    fn sources(&self) -> impl Iterator<Item = (&Path, &Source)> {
+        self.input
+            .sources
+            .iter()
+            .chain(self.input.interfaces.iter())
+            .map(|(path, source)| (path.as_path(), source))
     }
 }

--- a/src/compilers/vyper/mod.rs
+++ b/src/compilers/vyper/mod.rs
@@ -32,9 +32,32 @@ pub const VYPER_EXTENSIONS: &[&str] = &["vy", "vyi"];
 pub const VYPER_INTERFACE_EXTENSION: &str = "vyi";
 
 /// Vyper language, used as [Compiler::Language] for the Vyper compiler.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct VyperLanguage;
+
+impl serde::Serialize for VyperLanguage {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str("vyper")
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for VyperLanguage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let res = String::deserialize(deserializer)?;
+        if res != "vyper" {
+            Err(serde::de::Error::custom(format!("Invalid Vyper language: {}", res)))
+        } else {
+            Ok(VyperLanguage)
+        }
+    }
+}
 
 impl Language for VyperLanguage {
     const FILE_EXTENSIONS: &'static [&'static str] = VYPER_EXTENSIONS;

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -178,7 +178,7 @@ impl Flattener {
     /// into this function.
     pub fn new<C: Compiler>(
         project: &Project<C>,
-        output: &ProjectCompileOutput<C::CompilationError, ConfigurableArtifacts>,
+        output: &ProjectCompileOutput<C, ConfigurableArtifacts>,
         target: &Path,
     ) -> Result<Self>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
         println!("cargo:rerun-if-changed={}", self.paths.sources.display())
     }
 
-    pub fn compile(&self) -> Result<ProjectCompileOutput<C::CompilationError, T>> {
+    pub fn compile(&self) -> Result<ProjectCompileOutput<C, T>> {
         project::ProjectCompiler::new(self)?.compile()
     }
 
@@ -295,10 +295,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// let output = project.compile_file("example/Greeter.sol")?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn compile_file(
-        &self,
-        file: impl Into<PathBuf>,
-    ) -> Result<ProjectCompileOutput<C::CompilationError, T>> {
+    pub fn compile_file(&self, file: impl Into<PathBuf>) -> Result<ProjectCompileOutput<C, T>> {
         let file = file.into();
         let source = Source::read(&file)?;
         project::ProjectCompiler::with_sources(self, Sources::from([(file, source)]))?.compile()
@@ -316,10 +313,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// let output = project.compile_files(["examples/Foo.sol", "examples/Bar.sol"])?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn compile_files<P, I>(
-        &self,
-        files: I,
-    ) -> Result<ProjectCompileOutput<C::CompilationError, T>>
+    pub fn compile_files<P, I>(&self, files: I) -> Result<ProjectCompileOutput<C, T>>
     where
         I: IntoIterator<Item = P>,
         P: Into<PathBuf>,

--- a/src/project_util/mod.rs
+++ b/src/project_util/mod.rs
@@ -346,7 +346,7 @@ contract {} {{}}
         self.project().paths.root.as_path()
     }
 
-    pub fn compile(&self) -> Result<ProjectCompileOutput<C::CompilationError, T>> {
+    pub fn compile(&self) -> Result<ProjectCompileOutput<C, T>> {
         self.project().compile()
     }
 

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -11,8 +11,7 @@ use foundry_compilers::{
     cache::{CompilerCache, SOLIDITY_FILES_CACHE_FILENAME},
     compilers::{
         multi::{
-            MultiCompiler, MultiCompilerError, MultiCompilerLanguage, MultiCompilerParsedSource,
-            MultiCompilerSettings,
+            MultiCompiler, MultiCompilerLanguage, MultiCompilerParsedSource, MultiCompilerSettings,
         },
         solc::{SolcCompiler, SolcLanguage},
         vyper::{Vyper, VyperLanguage, VyperSettings},
@@ -327,7 +326,7 @@ fn can_compile_dapp_detect_changes_in_sources() {
     let cache = CompilerCache::<Settings>::read(&project.paths().cache).unwrap();
     assert_eq!(cache.files.len(), 2);
 
-    let mut artifacts = compiled.into_artifacts().collect::<HashMap<_, _>>();
+    let artifacts = compiled.into_artifacts().collect::<HashMap<_, _>>();
 
     // overwrite import
     let _ = project
@@ -356,8 +355,12 @@ fn can_compile_dapp_detect_changes_in_sources() {
 
     // and all recompiled artifacts are different
     for (p, artifact) in compiled.into_artifacts() {
-        let other = artifacts.remove(&p).unwrap();
-        assert_ne!(artifact, other);
+        let other = artifacts
+            .iter()
+            .find(|(id, _)| id.name == p.name && id.version == p.version && id.source == p.source)
+            .unwrap()
+            .1;
+        assert_ne!(artifact, *other);
     }
 }
 
@@ -2787,7 +2790,7 @@ fn compile_project_with_options(
     severity_filter: Option<foundry_compilers::artifacts::Severity>,
     ignore_paths: Option<Vec<PathBuf>>,
     ignore_error_code: Option<u64>,
-) -> ProjectCompileOutput<MultiCompilerError> {
+) -> ProjectCompileOutput<MultiCompiler> {
     let mut builder =
         Project::builder().no_artifacts().paths(gen_test_data_licensing_warning()).ephemeral();
 


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/7379
ref https://github.com/foundry-rs/foundry/issues/4981
ref https://github.com/foundry-rs/foundry/issues/2704

The way Solidity assigns `source_id`s is simply by order in which sources are passed in compiler input. Thus, if we have two sources `A.sol` and `B.sol`, then on the first (non-cached) compiler run, `A.sol` will get assigned ID 1 and `B.sol` will have ID 2.

Then, if we change `B.sol` slightly and recompile, it will be the only source in the input, so it will have ID 1.

The same ID collisions are more often appearing on multi-version and multi-compiler builds. After many cached runs such discrepancies result in debugger basically displaying random sources.

This PR adds a way to link an artifact to the build info for input that produced it, thus allowing us to track correct `source_id -> source` mapping for cached artifacts.

I've added `BuildContext` which is the foundry context we are tracking for each compiler invocation. It is getting inlined into `BuildInfo`, and read along with cached artifacts. `BuildContext`s are indexed by the same IDs `BuildInfo`s are, and each `ArtifactId` now has a reference to `build_id` which produced it.

Build info now produced on every compiler run, however, it does not include complete input and output unless `project.build_info` is true, to avoid overhead while keeping our internal logic working correctly.

