### PR TITLE
fix(flatten): small bugs

### DIFF
--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -28,6 +28,7 @@ pub use lowfidelity::{Ast, Node, NodeType, SourceLocation as LowFidelitySourceLo
 pub mod yul;
 
 use crate::serde_helpers;
+use core::fmt;
 use macros::{ast_node, expr_node, node_group, stmt_node};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -900,6 +901,16 @@ pub enum AssemblyReferenceSuffix {
     Offset,
     /// The reference refers to a length.
     Length,
+}
+
+impl fmt::Display for AssemblyReferenceSuffix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AssemblyReferenceSuffix::Slot => f.write_str("slot"),
+            AssemblyReferenceSuffix::Offset => f.write_str("offset"),
+            AssemblyReferenceSuffix::Length => f.write_str("length"),
+        }
+    }
 }
 
 /// Inline assembly flags.

--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -906,9 +906,9 @@ pub enum AssemblyReferenceSuffix {
 impl fmt::Display for AssemblyReferenceSuffix {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AssemblyReferenceSuffix::Slot => f.write_str("slot"),
-            AssemblyReferenceSuffix::Offset => f.write_str("offset"),
-            AssemblyReferenceSuffix::Length => f.write_str("length"),
+            Self::Slot => f.write_str("slot"),
+            Self::Offset => f.write_str("offset"),
+            Self::Length => f.write_str("length"),
         }
     }
 }

--- a/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/src/compilers/solc/compiler.rs
@@ -482,7 +482,7 @@ impl Solc {
         let solc = if let Some(solc) = Self::find_svm_installed_version(version)? {
             solc
         } else {
-            Self::blocking_install(&version)?
+            Self::blocking_install(version)?
         };
 
         Ok(solc)

--- a/crates/compilers/src/flatten.rs
+++ b/crates/compilers/src/flatten.rs
@@ -100,8 +100,10 @@ impl Visitor for ReferencesCollector {
         // If suffix is used in assembly reference (e.g. value.slot), it will be included into src.
         // However, we are only interested in the referenced name, thus we strip .<suffix> part.
         if let Some(suffix) = &reference.suffix {
-            let suffix_len = suffix.to_string().len();
-            src.length.as_mut().map(|len| *len -= suffix_len + 1);
+            if let Some(len) = src.length.as_mut() {
+                let suffix_len = suffix.to_string().len();
+                *len -= suffix_len + 1;
+            }
         }
 
         self.process_referenced_declaration(reference.declaration as isize, &src);


### PR DESCRIPTION
Found a couple bugs while testing https://github.com/foundry-rs/foundry/pull/8159 on random contracts.

Also updated `find_svm_installed_version` to accept `&Version` instead of relying on caller stripping of build metadata.