### PR TITLE
fix: doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,16 @@ jobs:
         shell: bash
         run: cargo nextest run ${{ matrix.flags }} --retries 2
 
-  # TODO: https://github.com/foundry-rs/compilers/issues/151
-  # doctest:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         cache-on-failure: true
-  #     - run: cargo test --workspace --doc
+  doctest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo test --workspace --doc --all-features
 
   feature-checks:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ foundry-compilers = { git = "https://github.com/foundry-rs/compilers" }
 
 Example usage:
 
-```rust
+```rust,ignore
 use foundry_compilers::{Project, ProjectPathsConfig};
 
 // configure the project with all its paths, solc, cache etc.
 let project = Project::builder()
     .paths(ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR")).unwrap())
-    .build()
+    .build(Default::default())
     .unwrap();
 let output = project.compile().unwrap();
 

--- a/crates/artifacts/solc/src/contract.rs
+++ b/crates/artifacts/solc/src/contract.rs
@@ -81,18 +81,6 @@ impl ContractBytecode {
     /// # Panics
     ///
     /// Panics if any field is `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use foundry_compilers::{artifacts::*, Project};
-    ///
-    /// let project = Project::builder().build()?;
-    /// let mut output = project.compile()?.into_output();
-    /// let contract: ContractBytecode = output.remove_first("Greeter").unwrap().into();
-    /// let contract: ContractBytecodeSome = contract.unwrap();
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
-    /// ```
     #[track_caller]
     pub fn unwrap(self) -> ContractBytecodeSome {
         ContractBytecodeSome {
@@ -344,18 +332,6 @@ impl CompactContract {
     /// # Panics
     ///
     /// Panics if any field is `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use foundry_compilers::{artifacts::*, Project};
-    ///
-    /// let project = Project::builder().build()?;
-    /// let mut output = project.compile()?.into_output();
-    /// let contract: CompactContract = output.remove_first("Greeter").unwrap().into();
-    /// let contract: CompactContractSome = contract.unwrap();
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
-    /// ```
     #[track_caller]
     pub fn unwrap(self) -> CompactContractSome {
         CompactContractSome {
@@ -531,18 +507,6 @@ impl<'a> CompactContractRef<'a> {
     /// # Panics
     ///
     /// Panics if any field is `None`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use foundry_compilers::{artifacts::*, Project};
-    ///
-    /// let project = Project::builder().build()?;
-    /// let output = project.compile()?.into_output();
-    /// let contract: CompactContractRef<'_> = output.find_first("Greeter").unwrap();
-    /// let contract: CompactContractRefSome<'_> = contract.unwrap();
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
-    /// ```
     #[track_caller]
     pub fn unwrap(self) -> CompactContractRefSome<'a> {
         CompactContractRefSome {

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -390,7 +390,7 @@ impl Settings {
     /// Inserts the value for all files and contracts
     ///
     /// ```
-    /// use foundry_compilers::artifacts::{output_selection::ContractOutputSelection, Settings};
+    /// use foundry_compilers_artifacts_solc::{output_selection::ContractOutputSelection, Settings};
     /// let mut selection = Settings::default();
     /// selection.push_output_selection(ContractOutputSelection::Metadata);
     /// ```
@@ -576,7 +576,7 @@ impl Libraries {
     /// # Examples
     ///
     /// ```
-    /// use foundry_compilers::artifacts::Libraries;
+    /// use foundry_compilers_artifacts_solc::Libraries;
     ///
     /// let libs = Libraries::parse(&[
     ///     "src/DssSpell.sol:DssExecLib:0xfD88CeE74f7D78697775aBDAE53f9Da1559728E4".to_string(),

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -101,12 +101,12 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// If the cache file does not exist
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{cache::SolFilesCache, Project};
+    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
     ///
-    /// let project = Project::builder().build()?;
-    /// let mut cache = SolFilesCache::read(project.cache_path())?;
+    /// let project = Project::builder().build(Default::default())?;
+    /// let mut cache = CompilerCache::<Settings>::read(project.cache_path())?;
     /// cache.join_artifacts_files(project.artifacts_path());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -128,12 +128,12 @@ impl<S: CompilerSettings> CompilerCache<S> {
     ///
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{cache::SolFilesCache, Project};
+    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
     ///
-    /// let project = Project::builder().build()?;
-    /// let cache = SolFilesCache::read_joined(&project.paths)?;
+    /// let project = Project::builder().build(Default::default())?;
+    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn read_joined<L>(paths: &ProjectPathsConfig<L>) -> Result<Self> {
@@ -213,13 +213,17 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// `src/Greeter.sol` if `base` is `/Users/me/project`
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{artifacts::contract::CompactContract, cache::SolFilesCache, Project};
+    /// use foundry_compilers::{
+    ///     artifacts::{contract::CompactContract, Settings},
+    ///     cache::CompilerCache,
+    ///     Project,
+    /// };
     ///
-    /// let project = Project::builder().build()?;
-    /// let cache =
-    ///     SolFilesCache::read(project.cache_path())?.with_stripped_file_prefixes(project.root());
+    /// let project = Project::builder().build(Default::default())?;
+    /// let cache: CompilerCache<Settings> =
+    ///     CompilerCache::read(project.cache_path())?.with_stripped_file_prefixes(project.root());
     /// let artifact: CompactContract = cache.read_artifact("src/Greeter.sol", "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -238,12 +242,12 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// Returns the path to the artifact of the given `(file, contract)` pair
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{cache::SolFilesCache, Project};
+    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
     ///
-    /// let project = Project::builder().build()?;
-    /// let cache = SolFilesCache::read_joined(&project.paths)?;
+    /// let project = Project::builder().build(Default::default())?;
+    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
     /// cache.find_artifact_path("/Users/git/myproject/src/Greeter.sol", "Greeter");
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -260,12 +264,16 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// [`Self::find_artifact_path()`]) and deserializes the artifact file as JSON.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{artifacts::contract::CompactContract, cache::SolFilesCache, Project};
+    /// use foundry_compilers::{
+    ///     artifacts::{contract::CompactContract, Settings},
+    ///     cache::CompilerCache,
+    ///     Project,
+    /// };
     ///
-    /// let project = Project::builder().build()?;
-    /// let cache = SolFilesCache::read_joined(&project.paths)?;
+    /// let project = Project::builder().build(Default::default())?;
+    /// let cache = CompilerCache::<Settings>::read_joined(&project.paths)?;
     /// let artifact: CompactContract =
     ///     cache.read_artifact("/Users/git/myproject/src/Greeter.sol", "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -292,14 +300,16 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// Reads all cached artifacts from disk using the given ArtifactOutput handler
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
-    ///     artifacts::contract::CompactContractBytecode, cache::SolFilesCache, Project,
+    ///     artifacts::{contract::CompactContractBytecode, Settings},
+    ///     cache::CompilerCache,
+    ///     Project,
     /// };
     ///
-    /// let project = Project::builder().build()?;
-    /// let cache = SolFilesCache::read_joined(&project.paths)?;
+    /// let project = Project::builder().build(Default::default())?;
+    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
     /// let artifacts = cache.read_artifacts::<CompactContractBytecode>()?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -858,7 +868,7 @@ pub(crate) enum ArtifactsCache<'a, T: ArtifactOutput, C: Compiler> {
 impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
     /// Create a new cache instance with the given files
     pub fn new(project: &'a Project<C, T>, edges: GraphEdges<C::ParsedSource>) -> Result<Self> {
-        /// Returns the [SolFilesCache] to use
+        /// Returns the [CompilerCache] to use
         ///
         /// Returns a new empty cache if the cache does not exist or `invalidate_cache` is set.
         fn get_cache<T: ArtifactOutput, C: Compiler>(

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -43,11 +43,11 @@ impl VersionedContracts {
     /// Finds the _first_ contract with the given name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let contract = output.find_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -62,11 +62,11 @@ impl VersionedContracts {
     /// Finds the contract with matching path and name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let contract = output.contracts.find("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -87,11 +87,11 @@ impl VersionedContracts {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let (_, mut contracts) = project.compile()?.into_output().split();
     /// let contract = contracts.remove_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -115,11 +115,11 @@ impl VersionedContracts {
     ///  Removes the contract with matching path and name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let (_, mut contracts) = project.compile()?.into_output().split();
     /// let contract = contracts.remove("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -112,12 +112,12 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// This returns a chained iterator of both cached and recompiled contract artifacts
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{ArtifactId, ConfigurableContractArtifact, Project};
+    /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, ArtifactId, Project};
     /// use std::collections::btree_map::BTreeMap;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let contracts: BTreeMap<ArtifactId, ConfigurableContractArtifact> =
     ///     project.compile()?.into_artifacts().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -131,12 +131,12 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// the contract name and the corresponding artifact
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{ConfigurableContractArtifact, Project};
+    /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
     /// use std::collections::btree_map::BTreeMap;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let artifacts: BTreeMap<String, &ConfigurableContractArtifact> =
     ///     project.compile()?.artifacts().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -149,13 +149,13 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// the contract name and the corresponding artifact with its version
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{ConfigurableContractArtifact, Project};
+    /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
     /// use semver::Version;
     /// use std::collections::btree_map::BTreeMap;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let artifacts: BTreeMap<String, (&ConfigurableContractArtifact, &Version)> =
     ///     project.compile()?.versioned_artifacts().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -192,13 +192,13 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// This returns a chained iterator of both cached and recompiled contract artifacts
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{ConfigurableContractArtifact, Project};
-    /// use std::collections::btree_map::BTreeMap;
+    /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
+    /// use std::{collections::btree_map::BTreeMap, path::PathBuf};
     ///
-    /// let project = Project::builder().build()?;
-    /// let contracts: Vec<(String, String, ConfigurableContractArtifact)> =
+    /// let project = Project::builder().build(Default::default())?;
+    /// let contracts: Vec<(PathBuf, String, ConfigurableContractArtifact)> =
     ///     project.compile()?.into_artifacts_with_files().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -237,14 +237,13 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// # Examples
     ///
     /// Make all artifact files relative to the project's root directory
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.with_stripped_file_prefixes(project.root());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
-    /// ```
     pub fn with_stripped_file_prefixes(mut self, base: impl AsRef<Path>) -> Self {
         let base = base.as_ref();
         self.cached_artifacts = self.cached_artifacts.into_stripped_file_prefixes(base);
@@ -256,12 +255,12 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Returns a reference to the (merged) solc compiler output.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::contract::Contract, Project};
     /// use std::collections::btree_map::BTreeMap;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let contracts: BTreeMap<String, Contract> =
     ///     project.compile()?.into_output().contracts_into_iter().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -331,11 +330,11 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// [`Self::remove_first`].
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
     /// let info = ContractInfo::new("src/Greeter.sol:Greeter");
     /// let contract = output.find_contract(&info).unwrap();
@@ -353,11 +352,11 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Finds the artifact with matching path and name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
     /// let contract = output.find("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -383,11 +382,11 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Finds the artifact with matching path and name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
     /// let contract = output.find("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -408,11 +407,11 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?;
     /// let contract = output.remove_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -433,11 +432,11 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     ///
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?;
     /// let info = ContractInfo::new("src/Greeter.sol:Greeter");
     /// let contract = output.remove_contract(&info).unwrap();
@@ -459,7 +458,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// [`foundry_compilers_artifacts::ConfigurableContractArtifact`]
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
     ///     artifacts::contract::CompactContractBytecode, contracts::ArtifactContracts, ArtifactId,
@@ -467,7 +466,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// };
     /// use std::collections::btree_map::BTreeMap;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let contracts: ArtifactContracts = project.compile()?.into_contract_bytecodes().collect();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -645,11 +644,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Finds the _first_ contract with the given name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let contract = output.find_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -661,11 +660,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?.into_output();
     /// let contract = output.remove_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -677,11 +676,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Removes the contract with matching path and name
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?.into_output();
     /// let contract = output.remove("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -701,11 +700,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// [Self::remove_first]
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?.into_output();
     /// let info = ContractInfo::new("src/Greeter.sol:Greeter");
     /// let contract = output.remove_contract(&info).unwrap();
@@ -765,11 +764,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// bytecode, runtime bytecode, and ABI.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let contract = output.get("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -786,11 +785,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// provide several helper methods
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let (sources, contracts) = output.split();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -815,11 +814,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// # Examples
     ///
     /// Make all sources and contracts relative to the project's root directory
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output().with_stripped_file_prefixes(project.root());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```

--- a/crates/compilers/src/compile/output/sources.rs
+++ b/crates/compilers/src/compile/output/sources.rs
@@ -55,11 +55,11 @@ impl VersionedSourceFiles {
     /// Finds the _first_ source file with the given path.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let source_file = output.sources.find_file("src/Greeter.sol").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -93,11 +93,11 @@ impl VersionedSourceFiles {
     /// Finds the _first_ source file with the given id
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
     /// let source_file = output.sources.find_id(0).unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -117,11 +117,11 @@ impl VersionedSourceFiles {
     /// Removes the _first_ source_file with the given path from the set
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let (mut sources, _) = project.compile()?.into_output().split();
     /// let source_file = sources.remove_by_path("src/Greeter.sol").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -140,11 +140,11 @@ impl VersionedSourceFiles {
     /// Removes the _first_ source_file with the given id from the set
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let (mut sources, _) = project.compile()?.into_output().split();
     /// let source_file = sources.remove_by_id(0).unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -176,11 +176,11 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
     /// `Contract`s
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/src/compilers/solc/compiler.rs
@@ -172,10 +172,13 @@ impl Solc {
     /// # Examples
     ///
     /// ```no_run
-    /// use foundry_compilers::Solc;
+    /// use foundry_compilers::solc::Solc;
+    /// use semver::Version;
     ///
-    /// let solc = Solc::find_svm_installed_version("0.8.9")?;
-    /// assert_eq!(solc, Some(Solc::new("~/.svm/0.8.9/solc-0.8.9")));
+    /// let solc = Solc::find_svm_installed_version(&Version::new(0, 8, 9))?;
+    /// assert_eq!(solc, Some(Solc::new("~/.svm/0.8.9/solc-0.8.9")?));
+    ///
+    /// Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn find_svm_installed_version(version: &Version) -> Result<Option<Self>> {
         let version = format!("{}.{}.{}", version.major, version.minor, version.patch);
@@ -235,7 +238,7 @@ impl Solc {
     /// # Examples
     ///
     /// ```no_run
-    /// use foundry_compilers::{Solc, ISTANBUL_SOLC};
+    /// use foundry_compilers::{solc::Solc, utils::ISTANBUL_SOLC};
     ///
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let solc = Solc::install(&ISTANBUL_SOLC).await?;
@@ -366,15 +369,17 @@ impl Solc {
     /// # Examples
     ///
     /// ```no_run
-    /// use foundry_compilers::{artifacts::Source, compilers::CompilerInput, Solc, SolcInput};
+    /// use foundry_compilers::{
+    ///     artifacts::{SolcInput, Source},
+    ///     compilers::{Compiler, CompilerInput},
+    ///     solc::Solc,
+    /// };
     ///
-    /// let solc = Solc::default();
-    /// let input = SolcInput::build(
+    /// let solc = Solc::new("solc")?;
+    /// let input = SolcInput::resolve_and_build(
     ///     Source::read_sol_yul_from("./contracts").unwrap(),
     ///     Default::default(),
-    ///     &("0.8.12".parse().unwrap()),
-    /// )
-    /// .unwrap();
+    /// );
     /// let output = solc.compile(&input)?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -103,11 +103,18 @@ impl Vyper {
     /// # Examples
     ///
     /// ```no_run
-    /// use foundry_compilers::{CompilerInput, Solc};
+    /// use foundry_compilers::{
+    ///     artifacts::{
+    ///         vyper::{VyperInput, VyperSettings},
+    ///         Source,
+    ///     },
+    ///     Vyper,
+    /// };
     ///
-    /// let solc = Solc::default();
-    /// let input = CompilerInput::new("./contracts")?;
-    /// let output = solc.compile(&input)?;
+    /// let vyper = Vyper::new("vyper")?;
+    /// let sources = Source::read_all_from("path/to/sources", &["vy", "vyi"])?;
+    /// let input = VyperInput::new(sources, VyperSettings::default());
+    /// let output = vyper.compile(&input)?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn compile<T: Serialize>(&self, input: &T) -> Result<VyperOutput> {

--- a/crates/compilers/src/config.rs
+++ b/crates/compilers/src/config.rs
@@ -342,7 +342,7 @@ impl<L> ProjectPathsConfig<L> {
     /// use foundry_compilers::ProjectPathsConfig;
     /// use std::path::Path;
     ///
-    /// let config = ProjectPathsConfig::builder().lib("lib").build()?;
+    /// let config: ProjectPathsConfig = ProjectPathsConfig::builder().lib("lib").build()?;
     /// assert_eq!(config.find_library_ancestor("lib/src/Greeter.sol"), Some(Path::new("lib")));
     /// Ok::<_, Box<dyn std::error::Error>>(())
     /// ```

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -110,30 +110,30 @@ impl Project {
     ///
     /// # Examples
     ///
-    /// Configure with `ConfigurableArtifacts` artifacts output:
-    ///
-    /// ```
+    /// Configure with [ConfigurableArtifacts] artifacts output and [MultiCompiler] compiler:
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
+    /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let config = Project::builder().build()?;
+    /// let config = Project::builder().build(Default::default())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
     /// To configure any a project with any `ArtifactOutput` use either:
-    ///
-    /// ```
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
+    /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let config = Project::builder().build()?;
+    /// let config = Project::builder().build(Default::default())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
     /// or use the builder directly:
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
+    /// ```no_run
+    /// use foundry_compilers::{multi::MultiCompiler, ConfigurableArtifacts, ProjectBuilder};
     ///
-    /// ```
-    /// use foundry_compilers::{ConfigurableArtifacts, ProjectBuilder};
-    ///
-    /// let config = ProjectBuilder::<ConfigurableArtifacts>::default().build()?;
+    /// let config = ProjectBuilder::<MultiCompiler>::default().build(Default::default())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn builder() -> ProjectBuilder {
@@ -254,14 +254,14 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Use this if you compile a project in a `build.rs` file.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{Project, ProjectPathsConfig};
     ///
     /// // Configure the project with all its paths, solc, cache etc.
     /// // where the root dir is the current Rust project.
     /// let paths = ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR"))?;
-    /// let project = Project::builder().paths(paths).build()?;
+    /// let project = Project::builder().paths(paths).build(Default::default())?;
     /// let output = project.compile()?;
     ///
     /// // Tell Cargo to rerun this build script that if a source file changes.
@@ -279,11 +279,11 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Convenience function to compile a single solidity file with the project's settings.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile_file("example/Greeter.sol")?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -297,11 +297,11 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Same as [`Self::compile()`] but with the given `files` as input.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile_files(["examples/Foo.sol", "examples/Bar.sol"])?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -320,11 +320,11 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// If the cache file was the only file in the folder, this also removes the empty folder.
     ///
     /// # Examples
-    ///
+    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```
     /// use foundry_compilers::Project;
     ///
-    /// let project = Project::builder().build()?;
+    /// let project = Project::builder().build(Default::default())?;
     /// let _ = project.compile()?;
     /// assert!(project.artifacts_path().exists());
     /// assert!(project.cache_path().exists());

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -154,8 +154,8 @@ pub fn source_files_iter<'a>(
 /// # Examples
 ///
 /// ```no_run
-/// use foundry_compilers::utils;
-/// let sources = utils::source_files("./contracts");
+/// use foundry_compilers_core::utils;
+/// let sources = utils::source_files("./contracts", &utils::SOLC_EXTENSIONS);
 /// ```
 pub fn source_files(root: impl AsRef<Path>, extensions: &[&str]) -> Vec<PathBuf> {
     source_files_iter(root, extensions).collect()
@@ -172,7 +172,7 @@ pub fn sol_source_files(root: impl AsRef<Path>) -> Vec<PathBuf> {
 /// # Examples
 ///
 /// ```no_run
-/// use foundry_compilers::utils;
+/// use foundry_compilers_core::utils;
 /// let dirs = utils::solidity_dirs("./lib");
 /// ```
 ///
@@ -440,7 +440,7 @@ pub fn library_hash(name: impl AsRef<[u8]>) -> [u8; 17] {
 /// # Examples
 ///
 /// ```
-/// use foundry_compilers::utils::common_ancestor_all;
+/// use foundry_compilers_core::utils::common_ancestor_all;
 /// use std::path::{Path, PathBuf};
 ///
 /// let baz = Path::new("/foo/bar/baz");
@@ -471,7 +471,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use foundry_compilers::utils::common_ancestor;
+/// use foundry_compilers_core::utils::common_ancestor;
 /// use std::path::{Path, PathBuf};
 ///
 /// let foo = Path::new("/foo/bar/foo");


### PR DESCRIPTION
Closes #151 

Removed some tests in artifacts relying on `Project`.

Some of the tests are feature-gated behind `svm-solc` to allow easier construction of project as there's no `Solc::default()` anymore.