### PR TITLE
chore: remove most impl AsRef<str,Path>

### DIFF
--- a/crates/artifacts/solc/src/ast/lowfidelity.rs
+++ b/crates/artifacts/solc/src/ast/lowfidelity.rs
@@ -53,9 +53,9 @@ pub struct Node {
 
 impl Node {
     /// Deserialize a serialized node attribute.
-    pub fn attribute<D: DeserializeOwned>(&self, key: impl AsRef<str>) -> Option<D> {
+    pub fn attribute<D: DeserializeOwned>(&self, key: &str) -> Option<D> {
         // TODO: Can we avoid this clone?
-        self.other.get(key.as_ref()).and_then(|v| serde_json::from_value(v.clone()).ok())
+        self.other.get(key).and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 }
 

--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -1100,30 +1100,28 @@ ast_node!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, path::PathBuf};
+    use std::{fs, path::Path};
 
     #[test]
     fn can_parse_ast() {
-        fs::read_dir(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../test-data").join("ast"),
-        )
-        .unwrap()
-        .for_each(|path| {
-            let path = path.unwrap().path();
-            let path_str = path.to_string_lossy();
+        fs::read_dir(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test-data").join("ast"))
+            .unwrap()
+            .for_each(|path| {
+                let path = path.unwrap().path();
+                let path_str = path.to_string_lossy();
 
-            let input = fs::read_to_string(&path).unwrap();
-            let deserializer = &mut serde_json::Deserializer::from_str(&input);
-            let result: Result<SourceUnit, _> = serde_path_to_error::deserialize(deserializer);
-            match result {
-                Err(e) => {
-                    println!("... {path_str} fail: {e}");
-                    panic!();
+                let input = fs::read_to_string(&path).unwrap();
+                let deserializer = &mut serde_json::Deserializer::from_str(&input);
+                let result: Result<SourceUnit, _> = serde_path_to_error::deserialize(deserializer);
+                match result {
+                    Err(e) => {
+                        println!("... {path_str} fail: {e}");
+                        panic!();
+                    }
+                    Ok(_) => {
+                        println!("... {path_str} ok");
+                    }
                 }
-                Ok(_) => {
-                    println!("... {path_str} ok");
-                }
-            }
-        })
+            })
     }
 }

--- a/crates/artifacts/solc/src/bytecode.rs
+++ b/crates/artifacts/solc/src/bytecode.rs
@@ -66,18 +66,11 @@ impl CompactBytecode {
     ///
     /// Returns true if the bytecode object is fully linked, false otherwise
     /// This is a noop if the bytecode object is already fully linked.
-    pub fn link(
-        &mut self,
-        file: impl AsRef<str>,
-        library: impl AsRef<str>,
-        address: Address,
-    ) -> bool {
+    pub fn link(&mut self, file: &str, library: &str, address: Address) -> bool {
         if !self.object.is_unlinked() {
             return true;
         }
 
-        let file = file.as_ref();
-        let library = library.as_ref();
         if let Some((key, mut contracts)) = self.link_references.remove_entry(file) {
             if contracts.remove(library).is_some() {
                 self.object.link(file, library, address);
@@ -148,8 +141,8 @@ impl Bytecode {
     }
 
     /// Same as `Bytecode::link` but with fully qualified name (`file.sol:Math`)
-    pub fn link_fully_qualified(&mut self, name: impl AsRef<str>, addr: Address) -> bool {
-        if let Some((file, lib)) = name.as_ref().split_once(':') {
+    pub fn link_fully_qualified(&mut self, name: &str, addr: Address) -> bool {
+        if let Some((file, lib)) = name.split_once(':') {
             self.link(file, lib, addr)
         } else {
             false
@@ -161,18 +154,11 @@ impl Bytecode {
     ///
     /// Returns true if the bytecode object is fully linked, false otherwise
     /// This is a noop if the bytecode object is already fully linked.
-    pub fn link(
-        &mut self,
-        file: impl AsRef<str>,
-        library: impl AsRef<str>,
-        address: Address,
-    ) -> bool {
+    pub fn link(&mut self, file: &str, library: &str, address: Address) -> bool {
         if !self.object.is_unlinked() {
             return true;
         }
 
-        let file = file.as_ref();
-        let library = library.as_ref();
         if let Some((key, mut contracts)) = self.link_references.remove_entry(file) {
             if contracts.remove(library).is_some() {
                 self.object.link(file, library, address);
@@ -195,7 +181,7 @@ impl Bytecode {
         T: AsRef<str>,
     {
         for (file, lib, addr) in libs.into_iter() {
-            if self.link(file, lib, addr) {
+            if self.link(file.as_ref(), lib.as_ref(), addr) {
                 return true;
             }
         }
@@ -209,7 +195,7 @@ impl Bytecode {
         S: AsRef<str>,
     {
         for (name, addr) in libs.into_iter() {
-            if self.link_fully_qualified(name, addr) {
+            if self.link_fully_qualified(name.as_ref(), addr) {
                 return true;
             }
         }
@@ -316,9 +302,8 @@ impl BytecodeObject {
     /// This will replace all occurrences of the library placeholder with the given address.
     ///
     /// See also: <https://docs.soliditylang.org/en/develop/using-the-compiler.html#library-linking>
-    pub fn link_fully_qualified(&mut self, name: impl AsRef<str>, addr: Address) -> &mut Self {
+    pub fn link_fully_qualified(&mut self, name: &str, addr: Address) -> &mut Self {
         if let Self::Unlinked(ref mut unlinked) = self {
-            let name = name.as_ref();
             let place_holder = utils::library_hash_placeholder(name);
             // the address as hex without prefix
             let hex_addr = hex::encode(addr);
@@ -337,13 +322,8 @@ impl BytecodeObject {
     /// Links using the `file` and `library` names as fully qualified name `<file>:<library>`.
     ///
     /// See [`link_fully_qualified`](Self::link_fully_qualified).
-    pub fn link(
-        &mut self,
-        file: impl AsRef<str>,
-        library: impl AsRef<str>,
-        addr: Address,
-    ) -> &mut Self {
-        self.link_fully_qualified(format!("{}:{}", file.as_ref(), library.as_ref()), addr)
+    pub fn link(&mut self, file: &str, library: &str, addr: Address) -> &mut Self {
+        self.link_fully_qualified(&format!("{file}:{library}"), addr)
     }
 
     /// Links the bytecode object with all provided `(file, lib, addr)`.
@@ -354,15 +334,14 @@ impl BytecodeObject {
         T: AsRef<str>,
     {
         for (file, lib, addr) in libs.into_iter() {
-            self.link(file, lib, addr);
+            self.link(file.as_ref(), lib.as_ref(), addr);
         }
         self
     }
 
     /// Returns whether the bytecode contains a matching placeholder using the qualified name.
-    pub fn contains_fully_qualified_placeholder(&self, name: impl AsRef<str>) -> bool {
+    pub fn contains_fully_qualified_placeholder(&self, name: &str) -> bool {
         if let Self::Unlinked(unlinked) = self {
-            let name = name.as_ref();
             unlinked.contains(&utils::library_hash_placeholder(name))
                 || unlinked.contains(&utils::library_fully_qualified_placeholder(name))
         } else {
@@ -371,8 +350,8 @@ impl BytecodeObject {
     }
 
     /// Returns whether the bytecode contains a matching placeholder.
-    pub fn contains_placeholder(&self, file: impl AsRef<str>, library: impl AsRef<str>) -> bool {
-        self.contains_fully_qualified_placeholder(format!("{}:{}", file.as_ref(), library.as_ref()))
+    pub fn contains_placeholder(&self, file: &str, library: &str) -> bool {
+        self.contains_fully_qualified_placeholder(&format!("{file}:{library}"))
     }
 }
 

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -158,15 +158,13 @@ impl SolcInput {
 
     /// Sets the path of the source files to `root` adjoined to the existing path
     #[must_use]
-    pub fn join_path(mut self, root: impl AsRef<Path>) -> Self {
-        let root = root.as_ref();
+    pub fn join_path(mut self, root: &Path) -> Self {
         self.sources = self.sources.into_iter().map(|(path, s)| (root.join(path), s)).collect();
         self
     }
 
     /// Removes the `base` path from all source files
-    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) {
-        let base = base.as_ref();
+    pub fn strip_prefix(&mut self, base: &Path) {
         self.sources = std::mem::take(&mut self.sources)
             .into_iter()
             .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
@@ -490,8 +488,7 @@ impl Settings {
         self
     }
 
-    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) {
-        let base = base.as_ref();
+    pub fn strip_prefix(&mut self, base: &Path) {
         self.remappings.iter_mut().for_each(|r| {
             r.strip_prefix(base);
         });
@@ -535,7 +532,7 @@ impl Settings {
     }
 
     /// Strips `base` from all paths
-    pub fn with_base_path(mut self, base: impl AsRef<Path>) -> Self {
+    pub fn with_base_path(mut self, base: &Path) -> Self {
         self.strip_prefix(base);
         self
     }
@@ -624,8 +621,7 @@ impl Libraries {
 
     /// Strips the given prefix from all library file paths to make them relative to the given
     /// `base` argument
-    pub fn with_stripped_file_prefixes(mut self, base: impl AsRef<Path>) -> Self {
-        let base = base.as_ref();
+    pub fn with_stripped_file_prefixes(mut self, base: &Path) -> Self {
         self.libs = self
             .libs
             .into_iter()
@@ -1510,16 +1506,14 @@ impl CompilerOutput {
     }
 
     /// Finds the _first_ contract with the given name
-    pub fn find(&self, contract: impl AsRef<str>) -> Option<CompactContractRef<'_>> {
-        let contract_name = contract.as_ref();
+    pub fn find(&self, contract_name: &str) -> Option<CompactContractRef<'_>> {
         self.contracts_iter().find_map(|(name, contract)| {
             (name == contract_name).then(|| CompactContractRef::from(contract))
         })
     }
 
     /// Finds the first contract with the given name and removes it from the set
-    pub fn remove(&mut self, contract: impl AsRef<str>) -> Option<Contract> {
-        let contract_name = contract.as_ref();
+    pub fn remove(&mut self, contract_name: &str) -> Option<Contract> {
         self.contracts.values_mut().find_map(|c| c.remove(contract_name))
     }
 
@@ -1586,16 +1580,14 @@ impl OutputContracts {
     }
 
     /// Finds the _first_ contract with the given name
-    pub fn find(&self, contract: impl AsRef<str>) -> Option<CompactContractRef<'_>> {
-        let contract_name = contract.as_ref();
+    pub fn find(&self, contract_name: &str) -> Option<CompactContractRef<'_>> {
         self.contracts_iter().find_map(|(name, contract)| {
             (name == contract_name).then(|| CompactContractRef::from(contract))
         })
     }
 
     /// Finds the first contract with the given name and removes it from the set
-    pub fn remove(&mut self, contract: impl AsRef<str>) -> Option<Contract> {
-        let contract_name = contract.as_ref();
+    pub fn remove(&mut self, contract_name: &str) -> Option<Contract> {
         self.0.values_mut().find_map(|c| c.remove(contract_name))
     }
 }
@@ -1920,7 +1912,7 @@ mod tests {
 
     #[test]
     fn can_parse_compiler_output() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/out");
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/out");
 
         for path in fs::read_dir(dir).unwrap() {
             let path = path.unwrap().path();
@@ -1933,7 +1925,7 @@ mod tests {
 
     #[test]
     fn can_parse_compiler_input() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/in");
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/in");
 
         for path in fs::read_dir(dir).unwrap() {
             let path = path.unwrap().path();
@@ -1946,7 +1938,7 @@ mod tests {
 
     #[test]
     fn can_parse_standard_json_compiler_input() {
-        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/in");
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/in");
 
         for path in fs::read_dir(dir).unwrap() {
             let path = path.unwrap().path();
@@ -2078,7 +2070,7 @@ mod tests {
 
         let libs = Libraries::parse(&libraries[..])
             .unwrap()
-            .with_stripped_file_prefixes("/global/root")
+            .with_stripped_file_prefixes("/global/root".as_ref())
             .libs;
 
         assert_eq!(
@@ -2208,8 +2200,8 @@ mod tests {
     // <https://github.com/foundry-rs/foundry/issues/3012>
     #[test]
     fn can_parse_compiler_output_spells_0_6_12() {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../../test-data/0.6.12-with-libs.json");
+        let path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../test-data/0.6.12-with-libs.json");
         let content = fs::read_to_string(path).unwrap();
         let _output: CompilerOutput = serde_json::from_str(&content).unwrap();
     }

--- a/crates/artifacts/solc/src/remappings.rs
+++ b/crates/artifacts/solc/src/remappings.rs
@@ -420,9 +420,9 @@ impl RelativeRemappingPathBuf {
     }
 }
 
-impl<P: AsRef<Path>> From<P> for RelativeRemappingPathBuf {
+impl<P: Into<PathBuf>> From<P> for RelativeRemappingPathBuf {
     fn from(path: P) -> Self {
-        Self { parent: None, path: path.as_ref().to_path_buf() }
+        Self { parent: None, path: path.into() }
     }
 }
 

--- a/crates/artifacts/solc/src/remappings.rs
+++ b/crates/artifacts/solc/src/remappings.rs
@@ -61,13 +61,13 @@ pub struct Remapping {
 
 impl Remapping {
     /// Convenience function for [`RelativeRemapping::new`]
-    pub fn into_relative(self, root: impl AsRef<Path>) -> RelativeRemapping {
+    pub fn into_relative(self, root: &Path) -> RelativeRemapping {
         RelativeRemapping::new(self, root)
     }
 
     /// Removes the `base` path from the remapping
-    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        if let Ok(stripped) = Path::new(&self.path).strip_prefix(base.as_ref()) {
+    pub fn strip_prefix(&mut self, base: &Path) -> &mut Self {
+        if let Ok(stripped) = Path::new(&self.path).strip_prefix(base) {
             self.path = format!("{}", stripped.display());
         }
         self
@@ -164,8 +164,10 @@ impl fmt::Display for Remapping {
 }
 
 impl Remapping {
-    /// Returns all formatted remappings
-    pub fn find_many_str(path: &str) -> Vec<String> {
+    /// Attempts to autodetect all remappings given a certain root path.
+    ///
+    /// See [`Self::find_many`] for more information.
+    pub fn find_many_str(path: &Path) -> Vec<String> {
         Self::find_many(path).into_iter().map(|r| r.to_string()).collect()
     }
 
@@ -201,7 +203,7 @@ impl Remapping {
     /// which would be multiple rededications according to our rules ("governance", "protocol-v2"),
     /// are unified into `@aave` by looking at their common ancestor, the root of this subdirectory
     /// (`@aave`)
-    pub fn find_many(dir: impl AsRef<Path>) -> Vec<Self> {
+    pub fn find_many(dir: &Path) -> Vec<Self> {
         /// prioritize
         ///   - ("a", "1/2") over ("a", "1/2/3")
         ///   - if a path ends with `src`
@@ -224,7 +226,6 @@ impl Remapping {
         // all combined remappings from all subdirs
         let mut all_remappings = HashMap::new();
 
-        let dir = dir.as_ref();
         let is_inside_node_modules = dir.ends_with("node_modules");
 
         let mut visited_symlink_dirs = HashSet::new();
@@ -290,13 +291,10 @@ pub struct RelativeRemapping {
 
 impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
-    pub fn new(remapping: Remapping, root: impl AsRef<Path>) -> Self {
+    pub fn new(remapping: Remapping, root: &Path) -> Self {
         Self {
             context: remapping.context.map(|c| {
-                RelativeRemappingPathBuf::with_root(root.as_ref(), c)
-                    .path
-                    .to_string_lossy()
-                    .to_string()
+                RelativeRemappingPathBuf::with_root(root, c).path.to_string_lossy().to_string()
             }),
             name: remapping.name,
             path: RelativeRemappingPathBuf::with_root(root, remapping.path),
@@ -390,15 +388,16 @@ pub struct RelativeRemappingPathBuf {
 impl RelativeRemappingPathBuf {
     /// Creates a new `RelativeRemappingPathBuf` that checks if the `path` is a child path of
     /// `parent`.
-    pub fn with_root(parent: impl AsRef<Path>, path: impl AsRef<Path>) -> Self {
-        let parent = parent.as_ref();
-        let path = path.as_ref();
-        if let Ok(path) = path.strip_prefix(parent) {
-            Self { parent: Some(parent.to_path_buf()), path: path.to_path_buf() }
-        } else if path.has_root() {
-            Self { parent: None, path: path.to_path_buf() }
+    pub fn with_root(
+        parent: impl AsRef<Path> + Into<PathBuf>,
+        path: impl AsRef<Path> + Into<PathBuf>,
+    ) -> Self {
+        if let Ok(path) = path.as_ref().strip_prefix(parent.as_ref()) {
+            Self { parent: Some(parent.into()), path: path.to_path_buf() }
+        } else if path.as_ref().has_root() {
+            Self { parent: None, path: path.into() }
         } else {
-            Self { parent: Some(parent.to_path_buf()), path: path.to_path_buf() }
+            Self { parent: Some(parent.into()), path: path.into() }
         }
     }
 
@@ -812,22 +811,22 @@ mod tests {
         let remapping = "oz=a/b/c/d";
         let remapping = Remapping::from_str(remapping).unwrap();
 
-        let relative = RelativeRemapping::new(remapping.clone(), "a/b/c");
+        let relative = RelativeRemapping::new(remapping.clone(), Path::new("a/b/c"));
         assert_eq!(relative.path.relative(), Path::new(&remapping.path));
         assert_eq!(relative.path.original(), Path::new("d"));
 
-        let relative = RelativeRemapping::new(remapping.clone(), "x/y");
+        let relative = RelativeRemapping::new(remapping.clone(), Path::new("x/y"));
         assert_eq!(relative.path.relative(), Path::new("x/y/a/b/c/d"));
         assert_eq!(relative.path.original(), Path::new(&remapping.path));
 
         let remapping = "oz=/a/b/c/d";
         let remapping = Remapping::from_str(remapping).unwrap();
-        let relative = RelativeRemapping::new(remapping.clone(), "a/b");
+        let relative = RelativeRemapping::new(remapping.clone(), Path::new("a/b"));
         assert_eq!(relative.path.relative(), Path::new(&remapping.path));
         assert_eq!(relative.path.original(), Path::new(&remapping.path));
         assert!(relative.path.parent.is_none());
 
-        let relative = RelativeRemapping::new(remapping, "/a/b");
+        let relative = RelativeRemapping::new(remapping, Path::new("/a/b"));
         assert_eq!(relative.to_relative_remapping(), Remapping::from_str("oz/=c/d/").unwrap());
     }
 
@@ -1100,8 +1099,7 @@ mod tests {
         ];
         mkdir_or_touch(tmp_dir_path, &paths[..]);
 
-        let path = tmp_dir_path.display().to_string();
-        let mut remappings = Remapping::find_many(path);
+        let mut remappings = Remapping::find_many(tmp_dir_path);
         remappings.sort_unstable();
 
         let mut expected = vec![
@@ -1209,8 +1207,7 @@ mod tests {
         let contract2 = dir2.join("contract.sol");
         touch(&contract2).unwrap();
 
-        let path = tmp_dir_path.display().to_string();
-        let mut remappings = Remapping::find_many(path);
+        let mut remappings = Remapping::find_many(&tmp_dir_path);
         remappings.sort_unstable();
         let mut expected = vec![
             Remapping {
@@ -1248,8 +1245,7 @@ mod tests {
         ];
         mkdir_or_touch(tmp_dir_path, &paths[..]);
 
-        let path = tmp_dir_path.display().to_string();
-        let mut remappings = Remapping::find_many(path);
+        let mut remappings = Remapping::find_many(tmp_dir_path);
         remappings.sort_unstable();
 
         let mut expected = vec![
@@ -1347,7 +1343,7 @@ mod tests {
         mkdir_or_touch(tmp_dir_path, &paths[..]);
 
         let path = tmp_dir_path.display().to_string();
-        let mut remappings = Remapping::find_many(path);
+        let mut remappings = Remapping::find_many(path.as_ref());
         remappings.sort_unstable();
 
         let mut expected = vec![

--- a/crates/artifacts/solc/src/sources.rs
+++ b/crates/artifacts/solc/src/sources.rs
@@ -32,9 +32,8 @@ impl Source {
     }
 
     /// Reads the file's content
-    #[instrument(level = "debug", skip_all, err)]
-    pub fn read(file: impl AsRef<Path>) -> Result<Self, SolcIoError> {
-        let file = file.as_ref();
+    #[instrument(name = "read_source", level = "debug", skip_all, err)]
+    pub fn read(file: &Path) -> Result<Self, SolcIoError> {
         trace!(file=%file.display());
         let mut content = fs::read_to_string(file).map_err(|err| SolcIoError::new(err, file))?;
 
@@ -47,15 +46,12 @@ impl Source {
     }
 
     /// Recursively finds all source files under the given dir path and reads them all
-    pub fn read_all_from(
-        dir: impl AsRef<Path>,
-        extensions: &[&str],
-    ) -> Result<Sources, SolcIoError> {
+    pub fn read_all_from(dir: &Path, extensions: &[&str]) -> Result<Sources, SolcIoError> {
         Self::read_all_files(utils::source_files(dir, extensions))
     }
 
     /// Recursively finds all solidity and yul files under the given dir path and reads them all
-    pub fn read_sol_yul_from(dir: impl AsRef<Path>) -> Result<Sources, SolcIoError> {
+    pub fn read_sol_yul_from(dir: &Path) -> Result<Sources, SolcIoError> {
         Self::read_all_from(dir, utils::SOLC_EXTENSIONS)
     }
 
@@ -110,8 +106,8 @@ impl Source {
 #[cfg(feature = "async")]
 impl Source {
     /// async version of `Self::read`
-    pub async fn async_read(file: impl AsRef<Path>) -> Result<Self, SolcIoError> {
-        let file = file.as_ref();
+    #[instrument(name = "async_read_source", level = "debug", skip_all, err)]
+    pub async fn async_read(file: &Path) -> Result<Self, SolcIoError> {
         let mut content =
             tokio::fs::read_to_string(file).await.map_err(|err| SolcIoError::new(err, file))?;
 
@@ -125,10 +121,10 @@ impl Source {
 
     /// Finds all source files under the given dir path and reads them all
     pub async fn async_read_all_from(
-        dir: impl AsRef<Path>,
+        dir: &Path,
         extensions: &[&str],
     ) -> Result<Sources, SolcIoError> {
-        Self::async_read_all(utils::source_files(dir.as_ref(), extensions)).await
+        Self::async_read_all(utils::source_files(dir, extensions)).await
     }
 
     /// async version of `Self::read_all`

--- a/crates/artifacts/vyper/src/settings.rs
+++ b/crates/artifacts/vyper/src/settings.rs
@@ -36,9 +36,7 @@ pub struct VyperSettings {
 }
 
 impl VyperSettings {
-    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) {
-        let base = base.as_ref();
-
+    pub fn strip_prefix(&mut self, base: &Path) {
         self.output_selection = OutputSelection(
             std::mem::take(&mut self.output_selection.0)
                 .into_iter()

--- a/crates/compilers/src/buildinfo.rs
+++ b/crates/compilers/src/buildinfo.rs
@@ -28,7 +28,7 @@ pub struct BuildInfo<I, O> {
 
 impl<I: DeserializeOwned, O: DeserializeOwned> BuildInfo<I, O> {
     /// Deserializes the `BuildInfo` object from the given file
-    pub fn read(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn read(path: &Path) -> Result<Self> {
         utils::read_json_file(path)
     }
 }
@@ -59,13 +59,13 @@ impl<L: Language> BuildContext<L> {
         Ok(Self { source_id_to_path, language: input.language() })
     }
 
-    pub fn join_all(&mut self, root: impl AsRef<Path>) {
+    pub fn join_all(&mut self, root: &Path) {
         self.source_id_to_path.values_mut().for_each(|path| {
-            *path = root.as_ref().join(path.as_path());
+            *path = root.join(path.as_path());
         });
     }
 
-    pub fn with_joined_paths(mut self, root: impl AsRef<Path>) -> Self {
+    pub fn with_joined_paths(mut self, root: &Path) -> Self {
         self.join_all(root);
         self
     }

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -218,7 +218,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// let project = Project::builder().build(Default::default())?;
     /// let cache: CompilerCache<Settings> =
     ///     CompilerCache::read(project.cache_path())?.with_stripped_file_prefixes(project.root());
-    /// let artifact: CompactContract = cache.read_artifact("src/Greeter.sol", "Greeter")?;
+    /// let artifact: CompactContract = cache.read_artifact("src/Greeter.sol".as_ref(), "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     ///
@@ -241,7 +241,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
-    /// cache.find_artifact_path("/Users/git/myproject/src/Greeter.sol", "Greeter");
+    /// cache.find_artifact_path("/Users/git/myproject/src/Greeter.sol".as_ref(), "Greeter");
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn find_artifact_path(&self, contract_file: &Path, contract_name: &str) -> Option<&Path> {
@@ -264,7 +264,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// let project = Project::builder().build(Default::default())?;
     /// let cache = CompilerCache::<Settings>::read_joined(&project.paths)?;
     /// let artifact: CompactContract =
-    ///     cache.read_artifact("/Users/git/myproject/src/Greeter.sol", "Greeter")?;
+    ///     cache.read_artifact("/Users/git/myproject/src/Greeter.sol".as_ref(), "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     ///

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -83,13 +83,13 @@ impl<S: CompilerSettings> CompilerCache<S> {
     }
 
     /// Returns the corresponding `CacheEntry` for the file if it exists
-    pub fn entry(&self, file: impl AsRef<Path>) -> Option<&CacheEntry<S>> {
-        self.files.get(file.as_ref())
+    pub fn entry(&self, file: &Path) -> Option<&CacheEntry<S>> {
+        self.files.get(file)
     }
 
     /// Returns the corresponding `CacheEntry` for the file if it exists
-    pub fn entry_mut(&mut self, file: impl AsRef<Path>) -> Option<&mut CacheEntry<S>> {
-        self.files.get_mut(file.as_ref())
+    pub fn entry_mut(&mut self, file: &Path) -> Option<&mut CacheEntry<S>> {
+        self.files.get_mut(file)
     }
 
     /// Reads the cache json file from the given path
@@ -111,8 +111,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     #[instrument(skip_all, name = "sol-files-cache::read")]
-    pub fn read(path: impl AsRef<Path>) -> Result<Self> {
-        let path = path.as_ref();
+    pub fn read(path: &Path) -> Result<Self> {
         trace!("reading solfiles cache at {}", path.display());
         let cache: Self = utils::read_json_file(path)?;
         trace!("read cache \"{}\" with {} entries", cache.format, cache.files.len());
@@ -143,8 +142,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     }
 
     /// Write the cache as json file to the given path
-    pub fn write(&self, path: impl AsRef<Path>) -> Result<()> {
-        let path = path.as_ref();
+    pub fn write(&self, path: &Path) -> Result<()> {
         trace!("writing cache with {} entries to json file: \"{}\"", self.len(), path.display());
         utils::create_parent_dir_all(path)?;
         utils::write_json_file(self, path, 128 * 1024)?;
@@ -153,8 +151,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     }
 
     /// Sets the `CacheEntry`'s file paths to `root` adjoined to `self.file`.
-    pub fn join_entries(&mut self, root: impl AsRef<Path>) -> &mut Self {
-        let root = root.as_ref();
+    pub fn join_entries(&mut self, root: &Path) -> &mut Self {
         self.files = std::mem::take(&mut self.files)
             .into_iter()
             .map(|(path, entry)| (root.join(path), entry))
@@ -163,8 +160,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     }
 
     /// Removes `base` from all `CacheEntry` paths
-    pub fn strip_entries_prefix(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        let base = base.as_ref();
+    pub fn strip_entries_prefix(&mut self, base: &Path) -> &mut Self {
         self.files = std::mem::take(&mut self.files)
             .into_iter()
             .map(|(path, entry)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), entry))
@@ -173,15 +169,13 @@ impl<S: CompilerSettings> CompilerCache<S> {
     }
 
     /// Sets the artifact files location to `base` adjoined to the `CachEntries` artifacts.
-    pub fn join_artifacts_files(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        let base = base.as_ref();
+    pub fn join_artifacts_files(&mut self, base: &Path) -> &mut Self {
         self.files.values_mut().for_each(|entry| entry.join_artifacts_files(base));
         self
     }
 
     /// Removes `base` from all artifact file paths
-    pub fn strip_artifact_files_prefixes(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        let base = base.as_ref();
+    pub fn strip_artifact_files_prefixes(&mut self, base: &Path) -> &mut Self {
         self.files.values_mut().for_each(|entry| entry.strip_artifact_files_prefixes(base));
         self
     }
@@ -229,8 +223,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// ```
     ///
     /// **Note:** this only affects the source files, see [`Self::strip_artifact_files_prefixes()`]
-    pub fn with_stripped_file_prefixes(mut self, base: impl AsRef<Path>) -> Self {
-        let base = base.as_ref();
+    pub fn with_stripped_file_prefixes(mut self, base: &Path) -> Self {
         self.files = self
             .files
             .into_iter()
@@ -251,11 +244,7 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// cache.find_artifact_path("/Users/git/myproject/src/Greeter.sol", "Greeter");
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn find_artifact_path(
-        &self,
-        contract_file: impl AsRef<Path>,
-        contract_name: impl AsRef<str>,
-    ) -> Option<&Path> {
+    pub fn find_artifact_path(&self, contract_file: &Path, contract_name: &str) -> Option<&Path> {
         let entry = self.entry(contract_file)?;
         entry.find_artifact_path(contract_name)
     }
@@ -283,17 +272,13 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// absolute.
     pub fn read_artifact<Artifact: DeserializeOwned>(
         &self,
-        contract_file: impl AsRef<Path>,
-        contract_name: impl AsRef<str>,
+        contract_file: &Path,
+        contract_name: &str,
     ) -> Result<Artifact> {
-        let contract_file = contract_file.as_ref();
-        let contract_name = contract_name.as_ref();
-
         let artifact_path =
             self.find_artifact_path(contract_file, contract_name).ok_or_else(|| {
                 SolcError::ArtifactNotFound(contract_file.to_path_buf(), contract_name.to_string())
             })?;
-
         utils::read_json_file(artifact_path)
     }
 
@@ -330,14 +315,13 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// objects, so we are basically just partially deserializing build infos here.
     ///
     /// [BuildContext]: crate::buildinfo::BuildContext
-    pub fn read_builds<L: Language>(&self, build_info_dir: impl AsRef<Path>) -> Result<Builds<L>> {
+    pub fn read_builds<L: Language>(&self, build_info_dir: &Path) -> Result<Builds<L>> {
         use rayon::prelude::*;
 
-        let build_info_dir = build_info_dir.as_ref();
         self.builds
             .par_iter()
             .map(|build_id| {
-                utils::read_json_file(build_info_dir.join(build_id).with_extension("json"))
+                utils::read_json_file(&build_info_dir.join(build_id).with_extension("json"))
                     .map(|b| (build_id.clone(), b))
             })
             .collect::<Result<_>>()
@@ -347,13 +331,12 @@ impl<S: CompilerSettings> CompilerCache<S> {
 
 #[cfg(feature = "async")]
 impl<S: CompilerSettings> CompilerCache<S> {
-    pub async fn async_read(path: impl AsRef<Path>) -> Result<Self> {
-        let path = path.as_ref().to_owned();
-        Self::asyncify(move || Self::read(path)).await
+    pub async fn async_read(path: &Path) -> Result<Self> {
+        let path = path.to_owned();
+        Self::asyncify(move || Self::read(&path)).await
     }
 
-    pub async fn async_write(&self, path: impl AsRef<Path>) -> Result<()> {
-        let path = path.as_ref();
+    pub async fn async_write(&self, path: &Path) -> Result<()> {
         let content = serde_json::to_vec(self)?;
         tokio::fs::write(path, content).await.map_err(|err| SolcError::io(err, path))
     }
@@ -462,13 +445,12 @@ impl<S> CacheEntry<S> {
     /// entry.find_artifact_path("Greeter");
     /// # }
     /// ```
-    pub fn find_artifact_path(&self, contract_name: impl AsRef<str>) -> Option<&Path> {
-        self.artifacts.get(contract_name.as_ref())?.iter().next().map(|(_, p)| p.path.as_path())
+    pub fn find_artifact_path(&self, contract_name: &str) -> Option<&Path> {
+        self.artifacts.get(contract_name)?.iter().next().map(|(_, p)| p.path.as_path())
     }
 
     /// Reads the last modification date from the file's metadata
-    pub fn read_last_modification_date(file: impl AsRef<Path>) -> Result<u64> {
-        let file = file.as_ref();
+    pub fn read_last_modification_date(file: &Path) -> Result<u64> {
         let last_modification_date = fs::metadata(file)
             .map_err(|err| SolcError::io(err, file.to_path_buf()))?
             .modified()
@@ -559,14 +541,12 @@ impl<S> CacheEntry<S> {
     }
 
     /// Sets the artifact's paths to `base` adjoined to the artifact's `path`.
-    pub fn join_artifacts_files(&mut self, base: impl AsRef<Path>) {
-        let base = base.as_ref();
+    pub fn join_artifacts_files(&mut self, base: &Path) {
         self.artifacts_mut().for_each(|a| a.path = base.join(&a.path))
     }
 
     /// Removes `base` from the artifact's path
-    pub fn strip_artifact_files_prefixes(&mut self, base: impl AsRef<Path>) {
-        let base = base.as_ref();
+    pub fn strip_artifact_files_prefixes(&mut self, base: &Path) {
         self.artifacts_mut().for_each(|a| {
             if let Ok(rem) = a.path.strip_prefix(base) {
                 a.path = rem.to_path_buf();

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -67,7 +67,7 @@ impl VersionedContracts {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
-    /// let contract = output.contracts.find("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = output.contracts.find("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn find(
@@ -117,7 +117,7 @@ impl VersionedContracts {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let (_, mut contracts) = project.compile()?.into_output().split();
-    /// let contract = contracts.remove("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = contracts.remove("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove(&mut self, path: &Path, contract_name: &str) -> Option<Contract> {

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -52,8 +52,7 @@ impl VersionedContracts {
     /// let contract = output.find_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn find_first(&self, contract: impl AsRef<str>) -> Option<CompactContractRef<'_>> {
-        let contract_name = contract.as_ref();
+    pub fn find_first(&self, contract_name: &str) -> Option<CompactContractRef<'_>> {
         self.contracts().find_map(|(name, contract)| {
             (name == contract_name).then(|| CompactContractRef::from(contract))
         })
@@ -73,11 +72,9 @@ impl VersionedContracts {
     /// ```
     pub fn find(
         &self,
-        path: impl AsRef<Path>,
-        contract: impl AsRef<str>,
+        contract_path: &Path,
+        contract_name: &str,
     ) -> Option<CompactContractRef<'_>> {
-        let contract_path = path.as_ref();
-        let contract_name = contract.as_ref();
         self.contracts_with_files().find_map(|(path, name, contract)| {
             (path == contract_path && name == contract_name)
                 .then(|| CompactContractRef::from(contract))
@@ -96,8 +93,7 @@ impl VersionedContracts {
     /// let contract = contracts.remove_first("Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn remove_first(&mut self, contract: impl AsRef<str>) -> Option<Contract> {
-        let contract_name = contract.as_ref();
+    pub fn remove_first(&mut self, contract_name: &str) -> Option<Contract> {
         self.0.values_mut().find_map(|all_contracts| {
             let mut contract = None;
             if let Some((c, mut contracts)) = all_contracts.remove_entry(contract_name) {
@@ -124,13 +120,8 @@ impl VersionedContracts {
     /// let contract = contracts.remove("src/Greeter.sol", "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn remove(
-        &mut self,
-        path: impl AsRef<Path>,
-        contract: impl AsRef<str>,
-    ) -> Option<Contract> {
-        let contract_name = contract.as_ref();
-        let (key, mut all_contracts) = self.0.remove_entry(path.as_ref())?;
+    pub fn remove(&mut self, path: &Path, contract_name: &str) -> Option<Contract> {
+        let (key, mut all_contracts) = self.0.remove_entry(path)?;
         let mut contract = None;
         if let Some((c, mut contracts)) = all_contracts.remove_entry(contract_name) {
             if !contracts.is_empty() {
@@ -149,14 +140,9 @@ impl VersionedContracts {
 
     /// Given the contract file's path and the contract's name, tries to return the contract's
     /// bytecode, runtime bytecode, and ABI.
-    pub fn get(
-        &self,
-        path: impl AsRef<Path>,
-        contract: impl AsRef<str>,
-    ) -> Option<CompactContractRef<'_>> {
-        let contract = contract.as_ref();
+    pub fn get(&self, path: &Path, contract: &str) -> Option<CompactContractRef<'_>> {
         self.0
-            .get(path.as_ref())
+            .get(path)
             .and_then(|contracts| {
                 contracts.get(contract).and_then(|c| c.first().map(|c| &c.contract))
             })
@@ -221,8 +207,7 @@ impl VersionedContracts {
     }
 
     /// Sets the contract's file paths to `root` adjoined to `self.file`.
-    pub fn join_all(&mut self, root: impl AsRef<Path>) -> &mut Self {
-        let root = root.as_ref();
+    pub fn join_all(&mut self, root: &Path) -> &mut Self {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
             .map(|(contract_path, contracts)| (root.join(contract_path), contracts))
@@ -231,8 +216,7 @@ impl VersionedContracts {
     }
 
     /// Removes `base` from all contract paths
-    pub fn strip_prefix_all(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        let base = base.as_ref();
+    pub fn strip_prefix_all(&mut self, base: &Path) -> &mut Self {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
             .map(|(contract_path, contracts)| {

--- a/crates/compilers/src/compile/output/info.rs
+++ b/crates/compilers/src/compile/output/info.rs
@@ -37,8 +37,7 @@ impl ContractInfo {
     ///     ContractInfo { path: Some("src/Greeter.sol".to_string()), name: "Greeter".to_string() }
     /// );
     /// ```
-    pub fn new(info: impl AsRef<str>) -> Self {
-        let info = info.as_ref();
+    pub fn new(info: &str) -> Self {
         info.parse().unwrap_or_else(|_| Self { path: None, name: info.to_string() })
     }
 }

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -357,7 +357,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
-    /// let contract = output.find("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = output.find("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn find(&self, path: &Path, name: &str) -> Option<&T::Artifact> {
@@ -384,7 +384,7 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?;
-    /// let contract = output.find("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = output.find("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove(&mut self, path: &Path, name: &str) -> Option<T::Artifact> {
@@ -670,7 +670,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let mut output = project.compile()?.into_output();
-    /// let contract = output.remove("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = output.remove("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove(&mut self, path: &Path, contract: &str) -> Option<Contract> {
@@ -754,7 +754,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
-    /// let contract = output.get("src/Greeter.sol", "Greeter").unwrap();
+    /// let contract = output.get("src/Greeter.sol".as_ref(), "Greeter").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn get(&self, path: &Path, contract: &str) -> Option<CompactContractRef<'_>> {

--- a/crates/compilers/src/compile/output/sources.rs
+++ b/crates/compilers/src/compile/output/sources.rs
@@ -64,17 +64,8 @@ impl VersionedSourceFiles {
     /// let source_file = output.sources.find_file("src/Greeter.sol").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn find_file(&self, source_file: impl AsRef<Path>) -> Option<&SourceFile> {
-        let source_file_name = source_file.as_ref();
-        self.sources().find_map(
-            |(path, source_file)| {
-                if path == source_file_name {
-                    Some(source_file)
-                } else {
-                    None
-                }
-            },
-        )
+    pub fn find_file(&self, path: &Path) -> Option<&SourceFile> {
+        self.sources().find(|&(p, _)| p == path).map(|(_, sf)| sf)
     }
 
     /// Same as [Self::find_file] but also checks for version
@@ -126,9 +117,8 @@ impl VersionedSourceFiles {
     /// let source_file = sources.remove_by_path("src/Greeter.sol").unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
-    pub fn remove_by_path(&mut self, source_file: impl AsRef<Path>) -> Option<SourceFile> {
-        let source_file_path = source_file.as_ref();
-        self.0.get_mut(source_file_path).and_then(|all_sources| {
+    pub fn remove_by_path(&mut self, path: &Path) -> Option<SourceFile> {
+        self.0.get_mut(path).and_then(|all_sources| {
             if !all_sources.is_empty() {
                 Some(all_sources.remove(0).source_file)
             } else {
@@ -192,8 +182,7 @@ impl VersionedSourceFiles {
     }
 
     /// Sets the sources' file paths to `root` adjoined to `self.file`.
-    pub fn join_all(&mut self, root: impl AsRef<Path>) -> &mut Self {
-        let root = root.as_ref();
+    pub fn join_all(&mut self, root: &Path) -> &mut Self {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
             .map(|(file_path, sources)| (root.join(file_path), sources))
@@ -202,8 +191,7 @@ impl VersionedSourceFiles {
     }
 
     /// Removes `base` from all source file paths
-    pub fn strip_prefix_all(&mut self, base: impl AsRef<Path>) -> &mut Self {
-        let base = base.as_ref();
+    pub fn strip_prefix_all(&mut self, base: &Path) -> &mut Self {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
             .map(|(file_path, sources)| {

--- a/crates/compilers/src/compile/output/sources.rs
+++ b/crates/compilers/src/compile/output/sources.rs
@@ -61,7 +61,7 @@ impl VersionedSourceFiles {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let output = project.compile()?.into_output();
-    /// let source_file = output.sources.find_file("src/Greeter.sol").unwrap();
+    /// let source_file = output.sources.find_file("src/Greeter.sol".as_ref()).unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn find_file(&self, path: &Path) -> Option<&SourceFile> {
@@ -114,7 +114,7 @@ impl VersionedSourceFiles {
     ///
     /// let project = Project::builder().build(Default::default())?;
     /// let (mut sources, _) = project.compile()?.into_output().split();
-    /// let source_file = sources.remove_by_path("src/Greeter.sol").unwrap();
+    /// let source_file = sources.remove_by_path("src/Greeter.sol".as_ref()).unwrap();
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn remove_by_path(&mut self, path: &Path) -> Option<SourceFile> {

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -641,9 +641,9 @@ mod tests {
 
     #[test]
     fn can_preprocess() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
         let project = Project::builder()
-            .paths(ProjectPathsConfig::dapptools(root).unwrap())
+            .paths(ProjectPathsConfig::dapptools(&root).unwrap())
             .build(Default::default())
             .unwrap();
 
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn can_detect_cached_files() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
         let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
         let project = TempProject::<MultiCompiler, MinimalCombinedArtifacts>::new(paths).unwrap();
 
@@ -795,7 +795,7 @@ mod tests {
 
     #[test]
     fn extra_output_cached() {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
         let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
         let mut project = TempProject::<MultiCompiler>::new(paths.clone()).unwrap();
 

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -213,8 +213,7 @@ impl<E> CompilerOutput<E> {
         self.sources.extend(other.sources);
     }
 
-    pub fn join_all(&mut self, root: impl AsRef<Path>) {
-        let root = root.as_ref();
+    pub fn join_all(&mut self, root: &Path) {
         self.contracts = std::mem::take(&mut self.contracts)
             .into_iter()
             .map(|(path, contracts)| (root.join(path), contracts))

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -71,15 +71,14 @@ pub struct Vyper {
 
 impl Vyper {
     /// Creates a new instance of the Vyper compiler. Uses the `vyper` binary in the system `PATH`.
-    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
-        let path = path.as_ref();
-        let version = Self::version(path)?;
-        Ok(Self { path: path.into(), version })
+    pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let version = Self::version(path.clone())?;
+        Ok(Self { path, version })
     }
 
     /// Convenience function for compiling all sources under the given path
-    pub fn compile_source(&self, path: impl AsRef<Path>) -> Result<VyperOutput> {
-        let path = path.as_ref();
+    pub fn compile_source(&self, path: &Path) -> Result<VyperOutput> {
         let input =
             VyperInput::new(Source::read_all_from(path, VYPER_EXTENSIONS)?, Default::default());
         self.compile(&input)
@@ -110,9 +109,11 @@ impl Vyper {
     ///     },
     ///     Vyper,
     /// };
+    /// use std::path::Path;
     ///
     /// let vyper = Vyper::new("vyper")?;
-    /// let sources = Source::read_all_from("path/to/sources", &["vy", "vyi"])?;
+    /// let path = Path::new("path/to/sources");
+    /// let sources = Source::read_all_from(path, &["vy", "vyi"])?;
     /// let input = VyperInput::new(sources, VyperSettings::default());
     /// let output = vyper.compile(&input)?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -256,7 +256,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     ///
     /// // Configure the project with all its paths, solc, cache etc.
     /// // where the root dir is the current Rust project.
-    /// let paths = ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR"))?;
+    /// let paths = ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR").as_ref())?;
     /// let project = Project::builder().paths(paths).build(Default::default())?;
     /// let output = project.compile()?;
     ///

--- a/crates/compilers/src/project_util/mock.rs
+++ b/crates/compilers/src/project_util/mock.rs
@@ -120,7 +120,7 @@ impl MockProjectGenerator {
         for file in self.inner.files.iter() {
             let imports = self.get_imports(file.id);
             let content = file.mock_content(version, imports.join("\n").as_str());
-            super::create_contract_file(&file.target_path(self, paths), &content)?;
+            super::create_contract_file(&file.target_path(self, paths), content)?;
         }
 
         Ok(())
@@ -346,7 +346,7 @@ impl MockProjectGenerator {
         let file = &self.inner.files[id];
         let target = file.target_path(self, paths);
         let content = file.modified_content(version, self.get_imports(id).join("\n").as_str());
-        super::create_contract_file(&target, &content)?;
+        super::create_contract_file(&target, content)?;
         Ok(target)
     }
 

--- a/crates/compilers/src/project_util/mock.rs
+++ b/crates/compilers/src/project_util/mock.rs
@@ -115,13 +115,12 @@ impl MockProjectGenerator {
     pub fn write_to<L: Language>(
         &self,
         paths: &ProjectPathsConfig<L>,
-        version: impl AsRef<str>,
+        version: &str,
     ) -> Result<()> {
-        let version = version.as_ref();
         for file in self.inner.files.iter() {
             let imports = self.get_imports(file.id);
             let content = file.mock_content(version, imports.join("\n").as_str());
-            super::create_contract_file(file.target_path(self, paths), content)?;
+            super::create_contract_file(&file.target_path(self, paths), &content)?;
         }
 
         Ok(())
@@ -342,13 +341,12 @@ impl MockProjectGenerator {
         &self,
         id: usize,
         paths: &ProjectPathsConfig,
-        version: impl AsRef<str>,
+        version: &str,
     ) -> Result<PathBuf> {
         let file = &self.inner.files[id];
         let target = file.target_path(self, paths);
         let content = file.modified_content(version, self.get_imports(id).join("\n").as_str());
-        super::create_contract_file(target.clone(), content)?;
-
+        super::create_contract_file(&target, &content)?;
         Ok(target)
     }
 
@@ -455,7 +453,7 @@ impl MockFile {
     /// Returns the content to use for a modified file
     ///
     /// The content here is arbitrary, it should only differ from the mocked content
-    pub fn modified_content(&self, version: impl AsRef<str>, imports: &str) -> String {
+    pub fn modified_content(&self, version: &str, imports: &str) -> String {
         format!(
             r#"
 // SPDX-License-Identifier: UNLICENSED
@@ -465,15 +463,12 @@ contract {} {{
     function hello() public {{}}
 }}
             "#,
-            version.as_ref(),
-            imports,
-            self.name
+            version, imports, self.name
         )
     }
 
     /// Returns a mocked content for the file
-    pub fn mock_content(&self, version: impl AsRef<str>, imports: &str) -> String {
-        let version = version.as_ref();
+    pub fn mock_content(&self, version: &str, imports: &str) -> String {
         if self.emit_artifacts {
             format!(
                 r#"

--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -259,7 +259,7 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
         let name = name.strip_suffix(".sol").unwrap_or(name);
         self.add_lib(
             name,
-            &format!(
+            format!(
                 r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity {version};
@@ -298,7 +298,7 @@ contract {name} {{}}
         let name = name.strip_suffix(".sol").unwrap_or(name);
         self.add_source(
             name,
-            &format!(
+            format!(
                 r#"
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity {version};

--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -53,11 +53,11 @@ impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
 
     /// Explicitly sets the solc version for the project
     #[cfg(feature = "svm-solc")]
-    pub fn set_solc(&mut self, solc: impl AsRef<str>) -> &mut Self {
+    pub fn set_solc(&mut self, solc: &str) -> &mut Self {
         use crate::compilers::{multi::MultiCompilerLanguage, solc::SolcLanguage};
         use semver::Version;
 
-        let version = Version::parse(solc.as_ref()).unwrap();
+        let version = Version::parse(solc).unwrap();
         self.inner
             .locked_versions
             .insert(MultiCompilerLanguage::Solc(SolcLanguage::Solidity), version.clone());
@@ -86,17 +86,17 @@ impl<T: ArtifactOutput> fmt::Debug for TempProject<MultiCompiler, T> {
     }
 }
 
-pub(crate) fn create_contract_file(path: PathBuf, content: impl AsRef<str>) -> Result<PathBuf> {
+pub(crate) fn create_contract_file(path: &Path, content: impl AsRef<str>) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|err| SolcIoError::new(err, parent.to_path_buf()))?;
     }
-    std::fs::write(&path, content.as_ref()).map_err(|err| SolcIoError::new(err, path.clone()))?;
-    Ok(path)
+    std::fs::write(path, content.as_ref()).map_err(|err| SolcIoError::new(err, path))?;
+    Ok(())
 }
 
-fn contract_file_name(name: impl AsRef<str>) -> String {
-    let name = name.as_ref().trim();
+fn contract_file_name(name: &str) -> String {
+    let name = name.trim();
     if name.ends_with(".sol") {
         name.to_string()
     } else {
@@ -177,9 +177,8 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
     /// Creates an initialized dapptools style workspace in a new temporary dir
     pub fn dapptools_init() -> Result<Self> {
         let mut project = Self::dapptools()?;
-        let orig_root =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
-        copy_dir(orig_root, project.root())?;
+        let orig_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+        copy_dir(&orig_root, project.root())?;
         project.project_mut().paths.remappings = Remapping::find_many(project.root());
         project.project_mut().paths.remappings.iter_mut().for_each(|r| r.slash_path());
 
@@ -205,7 +204,7 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
     }
 
     /// Copies a single file into the projects source
-    pub fn copy_source(&self, source: impl AsRef<Path>) -> Result<()> {
+    pub fn copy_source(&self, source: &Path) -> Result<()> {
         copy_file(source, &self.paths().sources)
     }
 
@@ -215,7 +214,7 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
         S: AsRef<Path>,
     {
         for path in sources {
-            self.copy_source(path)?;
+            self.copy_source(path.as_ref())?;
         }
         Ok(())
     }
@@ -229,9 +228,9 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
     }
 
     /// Copies a single file into the project's main library directory
-    pub fn copy_lib(&self, lib: impl AsRef<Path>) -> Result<()> {
+    pub fn copy_lib(&self, lib: &Path) -> Result<()> {
         let lib_dir = self.get_lib()?;
-        copy_file(lib, lib_dir)
+        copy_file(lib, &lib_dir)
     }
 
     /// Copy a series of files into the main library dir
@@ -241,90 +240,81 @@ impl<C: Compiler + Default, T: ArtifactOutput + Default> TempProject<C, T> {
         S: AsRef<Path>,
     {
         for path in libs {
-            self.copy_lib(path)?;
+            self.copy_lib(path.as_ref())?;
         }
         Ok(())
     }
 
     /// Adds a new library file
-    pub fn add_lib(&self, name: impl AsRef<str>, content: impl AsRef<str>) -> Result<PathBuf> {
+    pub fn add_lib(&self, name: &str, content: impl AsRef<str>) -> Result<PathBuf> {
         let name = contract_file_name(name);
         let lib_dir = self.get_lib()?;
         let lib = lib_dir.join(name);
-        create_contract_file(lib, content)
+        create_contract_file(&lib, content)?;
+        Ok(lib)
     }
 
     /// Adds a basic lib contract `contract <name> {}` as a new file
-    pub fn add_basic_lib(
-        &self,
-        name: impl AsRef<str>,
-        version: impl AsRef<str>,
-    ) -> Result<PathBuf> {
-        let name = name.as_ref();
+    pub fn add_basic_lib(&self, name: &str, version: &str) -> Result<PathBuf> {
         let name = name.strip_suffix(".sol").unwrap_or(name);
         self.add_lib(
             name,
-            format!(
+            &format!(
                 r#"
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity {};
-contract {} {{}}
+pragma solidity {version};
+contract {name} {{}}
             "#,
-                version.as_ref(),
-                name,
             ),
         )
     }
 
     /// Adds a new test file inside the project's test dir
-    pub fn add_test(&self, name: impl AsRef<str>, content: impl AsRef<str>) -> Result<PathBuf> {
+    pub fn add_test(&self, name: &str, content: impl AsRef<str>) -> Result<PathBuf> {
         let name = contract_file_name(name);
         let tests = self.paths().tests.join(name);
-        create_contract_file(tests, content)
+        create_contract_file(&tests, content)?;
+        Ok(tests)
     }
 
     /// Adds a new script file inside the project's script dir
-    pub fn add_script(&self, name: impl AsRef<str>, content: impl AsRef<str>) -> Result<PathBuf> {
+    pub fn add_script(&self, name: &str, content: impl AsRef<str>) -> Result<PathBuf> {
         let name = contract_file_name(name);
         let script = self.paths().scripts.join(name);
-        create_contract_file(script, content)
+        create_contract_file(&script, content)?;
+        Ok(script)
     }
 
     /// Adds a new source file inside the project's source dir
-    pub fn add_source(&self, name: impl AsRef<str>, content: impl AsRef<str>) -> Result<PathBuf> {
+    pub fn add_source(&self, name: &str, content: impl AsRef<str>) -> Result<PathBuf> {
         let name = contract_file_name(name);
         let source = self.paths().sources.join(name);
-        create_contract_file(source, content)
+        create_contract_file(&source, content)?;
+        Ok(source)
     }
 
     /// Adds a basic source contract `contract <name> {}` as a new file
-    pub fn add_basic_source(
-        &self,
-        name: impl AsRef<str>,
-        version: impl AsRef<str>,
-    ) -> Result<PathBuf> {
-        let name = name.as_ref();
+    pub fn add_basic_source(&self, name: &str, version: &str) -> Result<PathBuf> {
         let name = name.strip_suffix(".sol").unwrap_or(name);
         self.add_source(
             name,
-            format!(
+            &format!(
                 r#"
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity {};
-contract {} {{}}
+pragma solidity {version};
+contract {name} {{}}
             "#,
-                version.as_ref(),
-                name,
             ),
         )
     }
 
     /// Adds a solidity contract in the project's root dir.
     /// This will also create all intermediary dirs.
-    pub fn add_contract(&self, name: impl AsRef<str>, content: impl AsRef<str>) -> Result<PathBuf> {
+    pub fn add_contract(&self, name: &str, content: impl AsRef<str>) -> Result<PathBuf> {
         let name = contract_file_name(name);
         let source = self.root().join(name);
-        create_contract_file(source, content)
+        create_contract_file(&source, content)?;
+        Ok(source)
     }
 
     /// Returns the path to the artifacts directory
@@ -359,7 +349,7 @@ contract {} {{}}
     }
 
     /// Populate the project with mock files
-    pub fn mock(&self, gen: &MockProjectGenerator, version: impl AsRef<str>) -> Result<()> {
+    pub fn mock(&self, gen: &MockProjectGenerator, version: &str) -> Result<()> {
         gen.write_to(self.paths(), version)
     }
 
@@ -449,9 +439,9 @@ impl TempProject {
     }
 
     /// Clones the given repo into a temp dir, initializes it recursively and configures it.
-    pub fn checkout(repo: impl AsRef<str>) -> Result<Self> {
+    pub fn checkout(repo: &str) -> Result<Self> {
         let tmp_dir = tempdir("tmp_checkout")?;
-        clone_remote(&format!("https://github.com/{}", repo.as_ref()), tmp_dir.path())
+        clone_remote(&format!("https://github.com/{repo}"), tmp_dir.path())
             .map_err(|err| SolcIoError::new(err, tmp_dir.path()))?;
         let paths = ProjectPathsConfig::dapptools(tmp_dir.path())?;
 
@@ -460,7 +450,7 @@ impl TempProject {
     }
 
     /// Create a new temporary project and populate it with mock files.
-    pub fn mocked(settings: &MockProjectSettings, version: impl AsRef<str>) -> Result<Self> {
+    pub fn mocked(settings: &MockProjectSettings, version: &str) -> Result<Self> {
         let mut tmp = Self::dapptools()?;
         let gen = MockProjectGenerator::new(settings);
         tmp.mock(&gen, version)?;
@@ -470,7 +460,7 @@ impl TempProject {
     }
 
     /// Create a new temporary project and populate it with a random layout.
-    pub fn mocked_random(version: impl AsRef<str>) -> Result<Self> {
+    pub fn mocked_random(version: &str) -> Result<Self> {
         Self::mocked(&MockProjectSettings::random(), version)
     }
 }
@@ -524,32 +514,27 @@ fn file_copy_options() -> file::CopyOptions {
 }
 
 /// Copies a single file into the given dir
-pub fn copy_file(source: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Result<()> {
-    let source = source.as_ref();
-    let target = target_dir.as_ref().join(
+pub fn copy_file(source: &Path, target_dir: &Path) -> Result<()> {
+    let target = target_dir.join(
         source
             .file_name()
             .ok_or_else(|| SolcError::msg(format!("No file name for {}", source.display())))?,
     );
-
     fs_extra::file::copy(source, target, &file_copy_options())?;
     Ok(())
 }
 
 /// Copies all content of the source dir into the target dir
-pub fn copy_dir(source: impl AsRef<Path>, target_dir: impl AsRef<Path>) -> Result<()> {
+pub fn copy_dir(source: &Path, target_dir: &Path) -> Result<()> {
     fs_extra::dir::copy(source, target_dir, &dir_copy_options())?;
     Ok(())
 }
 
 /// Clones a remote repository into the specified directory.
-pub fn clone_remote(
-    repo_url: &str,
-    target_dir: impl AsRef<Path>,
-) -> std::io::Result<process::Output> {
+pub fn clone_remote(repo_url: &str, target_dir: &Path) -> std::io::Result<process::Output> {
     Command::new("git")
         .args(["clone", "--depth", "1", "--recursive", repo_url])
-        .arg(target_dir.as_ref())
+        .arg(target_dir)
         .output()
 }
 

--- a/crates/compilers/src/report/compiler.rs
+++ b/crates/compilers/src/report/compiler.rs
@@ -50,8 +50,8 @@ impl SolcCompilerIoReporter {
 
     /// Returns a new `SolcCompilerIOLayer` from the value of the given environment
     /// variable, ignoring any invalid filter directives.
-    pub fn from_env<A: AsRef<str>>(env: A) -> Self {
-        env::var(env.as_ref()).map(|var| Self::new(&var)).unwrap_or_default()
+    pub fn from_env(env: impl AsRef<std::ffi::OsStr>) -> Self {
+        env::var(env).map(|var| Self::new(&var)).unwrap_or_default()
     }
 
     /// Callback to write the input to disk if target is set

--- a/crates/compilers/src/report/compiler.rs
+++ b/crates/compilers/src/report/compiler.rs
@@ -32,8 +32,8 @@ pub struct SolcCompilerIoReporter {
 impl SolcCompilerIoReporter {
     /// Returns a new `SolcCompilerIOLayer` from the fields in the given string,
     /// ignoring any that are invalid.
-    pub fn new(value: impl AsRef<str>) -> Self {
-        Self { target: Some(value.as_ref().parse().unwrap_or_default()) }
+    pub fn new(value: &str) -> Self {
+        Self { target: Some(value.parse().unwrap_or_default()) }
     }
 
     /// `foundry_compilers_LOG` is the default environment variable used by
@@ -51,7 +51,7 @@ impl SolcCompilerIoReporter {
     /// Returns a new `SolcCompilerIOLayer` from the value of the given environment
     /// variable, ignoring any invalid filter directives.
     pub fn from_env<A: AsRef<str>>(env: A) -> Self {
-        env::var(env.as_ref()).map(Self::new).unwrap_or_default()
+        env::var(env.as_ref()).map(|var| Self::new(&var)).unwrap_or_default()
     }
 
     /// Callback to write the input to disk if target is set
@@ -69,12 +69,9 @@ impl SolcCompilerIoReporter {
     }
 }
 
-impl<S> From<S> for SolcCompilerIoReporter
-where
-    S: AsRef<str>,
-{
+impl<S: AsRef<str>> From<S> for SolcCompilerIoReporter {
     fn from(s: S) -> Self {
-        Self::new(s)
+        Self::new(s.as_ref())
     }
 }
 

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -2255,7 +2255,7 @@ fn can_recompile_with_changes() {
     assert!(compiled.is_unchanged());
 
     // modify A.sol
-    tmp.add_source("A", &format!("{content}\n")).unwrap();
+    tmp.add_source("A", format!("{content}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2310,7 +2310,7 @@ fn can_recompile_with_lowercase_names() {
     assert!(compiled.is_unchanged());
 
     // modify upgradeProxy.sol
-    tmp.add_source("upgradeProxy.sol", &format!("{upgrade}\n")).unwrap();
+    tmp.add_source("upgradeProxy.sol", format!("{upgrade}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2363,7 +2363,7 @@ fn can_recompile_unchanged_with_empty_files() {
     assert!(compiled.is_unchanged());
 
     // modify C.sol
-    tmp.add_source("C", &format!("{c}\n")).unwrap();
+    tmp.add_source("C", format!("{c}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2903,7 +2903,7 @@ fn can_install_solc_and_compile_version() {
     project
         .add_source(
             "Contract",
-            &format!(
+            format!(
                 r#"
 pragma solidity {version};
 contract Contract {{ }}

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -48,7 +48,7 @@ pub static VYPER: Lazy<Vyper> = Lazy::new(|| {
         let path = std::env::temp_dir().join("vyper");
 
         if path.exists() {
-            return Vyper::new(path).unwrap();
+            return Vyper::new(&path).unwrap();
         }
 
         let url = match platform() {
@@ -69,14 +69,14 @@ pub static VYPER: Lazy<Vyper> = Lazy::new(|| {
         #[cfg(target_family = "unix")]
         std::fs::set_permissions(&path, Permissions::from_mode(0o755)).unwrap();
 
-        Vyper::new(path).unwrap()
+        Vyper::new(&path).unwrap()
     })
 });
 
 #[test]
 fn can_get_versioned_linkrefs() {
     let root =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/test-versioned-linkrefs");
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/test-versioned-linkrefs");
     let paths = ProjectPathsConfig::builder()
         .sources(root.join("src"))
         .lib(root.join("lib"))
@@ -94,7 +94,7 @@ fn can_get_versioned_linkrefs() {
 
 #[test]
 fn can_compile_hardhat_sample() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/hardhat-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/hardhat-sample");
     let paths = ProjectPathsConfig::builder()
         .sources(root.join("contracts"))
         .lib(root.join("node_modules"));
@@ -121,7 +121,7 @@ fn can_compile_hardhat_sample() {
 
 #[test]
 fn can_compile_dapp_sample() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
     let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
     let project = TempProject::<SolcCompiler, ConfigurableArtifacts>::new(paths).unwrap();
 
@@ -148,7 +148,7 @@ fn can_compile_dapp_sample() {
 
 #[test]
 fn can_compile_yul_sample() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/yul-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/yul-sample");
     let paths = ProjectPathsConfig::builder().sources(root);
     let project = TempProject::<SolcCompiler, ConfigurableArtifacts>::new(paths).unwrap();
 
@@ -178,7 +178,7 @@ fn can_compile_yul_sample() {
 
 #[test]
 fn can_compile_configured() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
     let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
 
     let handler = ConfigurableArtifacts {
@@ -399,7 +399,7 @@ contract B { }
     let mut build_info_count = 0;
     for entry in fs::read_dir(info_dir).unwrap() {
         let _info =
-            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(entry.unwrap().path()).unwrap();
+            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(&entry.unwrap().path()).unwrap();
         build_info_count += 1;
     }
     assert_eq!(build_info_count, 1);
@@ -441,7 +441,7 @@ contract B { }
     let mut build_info_count = 0;
     for entry in fs::read_dir(info_dir).unwrap() {
         let _info =
-            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(entry.unwrap().path()).unwrap();
+            BuildInfo::<SolcInput, CompilerOutput<Error>>::read(&entry.unwrap().path()).unwrap();
         build_info_count += 1;
     }
     assert_eq!(build_info_count, 1);
@@ -458,10 +458,10 @@ fn can_compile_dapp_sample_with_cache() {
     let cache = root.join("cache").join(SOLIDITY_FILES_CACHE_FILENAME);
     let artifacts = root.join("out");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let orig_root = manifest_dir.join("../../test-data/dapp-sample");
     let cache_testdata_dir = manifest_dir.join("../../test-data/cache-sample/");
-    copy_dir_all(orig_root, &tmp_dir).unwrap();
+    copy_dir_all(&orig_root, tmp_dir.path()).unwrap();
     let paths = ProjectPathsConfig::builder()
         .cache(cache)
         .sources(root.join("src"))
@@ -524,15 +524,15 @@ fn can_compile_dapp_sample_with_cache() {
     assert!(compiled.find_first("Dapp").is_none());
 }
 
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
-    std::fs::create_dir_all(&dst)?;
+fn copy_dir_all(src: &Path, dst: &Path) -> io::Result<()> {
+    std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
         if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            copy_dir_all(&entry.path(), &dst.join(entry.file_name()))?;
         } else {
-            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            std::fs::copy(entry.path(), dst.join(entry.file_name()))?;
         }
     }
     Ok(())
@@ -553,7 +553,7 @@ fn test_flatteners(project: &TempProject, target: &Path, additional_checks: fn(&
 
 #[test]
 fn can_flatten_file_with_external_lib() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/hardhat-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/hardhat-sample");
     let paths = ProjectPathsConfig::builder()
         .sources(root.join("contracts"))
         .lib(root.join("node_modules"));
@@ -570,7 +570,7 @@ fn can_flatten_file_with_external_lib() {
 
 #[test]
 fn can_flatten_file_in_dapp_sample() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
     let paths = ProjectPathsConfig::builder().sources(root.join("src")).lib(root.join("lib"));
     let project = TempProject::<MultiCompiler>::new(paths).unwrap();
 
@@ -2255,7 +2255,7 @@ fn can_recompile_with_changes() {
     assert!(compiled.is_unchanged());
 
     // modify A.sol
-    tmp.add_source("A", format!("{content}\n")).unwrap();
+    tmp.add_source("A", &format!("{content}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2310,7 +2310,7 @@ fn can_recompile_with_lowercase_names() {
     assert!(compiled.is_unchanged());
 
     // modify upgradeProxy.sol
-    tmp.add_source("upgradeProxy.sol", format!("{upgrade}\n")).unwrap();
+    tmp.add_source("upgradeProxy.sol", &format!("{upgrade}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2363,7 +2363,7 @@ fn can_recompile_unchanged_with_empty_files() {
     assert!(compiled.is_unchanged());
 
     // modify C.sol
-    tmp.add_source("C", format!("{c}\n")).unwrap();
+    tmp.add_source("C", &format!("{c}\n")).unwrap();
     let compiled = tmp.compile().unwrap();
     compiled.assert_success();
     assert!(!compiled.is_unchanged());
@@ -2503,22 +2503,22 @@ fn can_detect_contract_def_source_files() {
     compiled.assert_success();
 
     let mut sources = compiled.into_output().sources;
-    let myfunc = sources.remove_by_path(myfunc).unwrap();
+    let myfunc = sources.remove_by_path(&myfunc).unwrap();
     assert!(!myfunc.contains_contract_definition());
 
-    let myerr = sources.remove_by_path(myerr).unwrap();
+    let myerr = sources.remove_by_path(&myerr).unwrap();
     assert!(!myerr.contains_contract_definition());
 
-    let mylib = sources.remove_by_path(mylib).unwrap();
+    let mylib = sources.remove_by_path(&mylib).unwrap();
     assert!(mylib.contains_contract_definition());
 
-    let myabstract_contract = sources.remove_by_path(myabstract_contract).unwrap();
+    let myabstract_contract = sources.remove_by_path(&myabstract_contract).unwrap();
     assert!(myabstract_contract.contains_contract_definition());
 
-    let myinterface = sources.remove_by_path(myinterface).unwrap();
+    let myinterface = sources.remove_by_path(&myinterface).unwrap();
     assert!(myinterface.contains_contract_definition());
 
-    let mycontract = sources.remove_by_path(mycontract).unwrap();
+    let mycontract = sources.remove_by_path(&mycontract).unwrap();
     assert!(mycontract.contains_contract_definition());
 }
 
@@ -2578,7 +2578,7 @@ fn can_compile_sparse_with_link_references() {
     assert!(lib.is_none());
 
     #[cfg(not(windows))]
-    let info = ContractInfo::new(format!("{}:{}", my_lib_path.display(), "MyLib"));
+    let info = ContractInfo::new(&format!("{}:{}", my_lib_path.display(), "MyLib"));
     #[cfg(windows)]
     let info = {
         use path_slash::PathBufExt;
@@ -2656,7 +2656,7 @@ fn can_create_standard_json_input_with_external_file() {
     compiled.assert_success();
 
     // can create project root based paths
-    let std_json = verif_project.standard_json_input(verif_dir.join("src/Counter.sol")).unwrap();
+    let std_json = verif_project.standard_json_input(&verif_dir.join("src/Counter.sol")).unwrap();
     assert_eq!(
         std_json.sources.iter().map(|(path, _)| path.clone()).collect::<Vec<_>>(),
         vec![
@@ -2684,7 +2684,7 @@ fn can_compile_std_json_input() {
     let tmp = TempProject::<MultiCompiler>::dapptools_init().unwrap();
     tmp.assert_no_errors();
     let source = tmp.list_source_files().into_iter().find(|p| p.ends_with("Dapp.t.sol")).unwrap();
-    let input = tmp.project().standard_json_input(source).unwrap();
+    let input = tmp.project().standard_json_input(&source).unwrap();
 
     assert!(input.settings.remappings.contains(&"ds-test/=lib/ds-test/src/".parse().unwrap()));
     let input: SolcInput = input.into();
@@ -2745,7 +2745,7 @@ fn can_create_standard_json_input_with_symlink() {
 
     // can create project root based paths
     let std_json =
-        project.project().standard_json_input(project.sources_path().join("A.sol")).unwrap();
+        project.project().standard_json_input(&project.sources_path().join("A.sol")).unwrap();
     assert_eq!(
         std_json.sources.iter().map(|(path, _)| path.clone()).collect::<Vec<_>>(),
         vec![
@@ -2770,8 +2770,7 @@ fn can_create_standard_json_input_with_symlink() {
 
 #[test]
 fn can_compile_model_checker_sample() {
-    let root =
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/model-checker-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/model-checker-sample");
     let paths = ProjectPathsConfig::builder().sources(root);
 
     let mut project = TempProject::<MultiCompiler, ConfigurableArtifacts>::new(paths).unwrap();
@@ -2790,8 +2789,8 @@ fn can_compile_model_checker_sample() {
 #[test]
 fn test_compiler_severity_filter() {
     fn gen_test_data_warning_path() -> ProjectPathsConfig {
-        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../test-data/test-contract-warnings");
+        let root =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/test-contract-warnings");
 
         ProjectPathsConfig::builder().sources(root).build().unwrap()
     }
@@ -2820,7 +2819,7 @@ fn test_compiler_severity_filter() {
 
 fn gen_test_data_licensing_warning() -> ProjectPathsConfig {
     let root = canonicalize(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test-data/test-contract-warnings/LicenseWarning.sol"),
     )
     .unwrap();
@@ -2858,7 +2857,7 @@ fn test_compiler_ignored_file_paths() {
     compiled.assert_success();
 
     let testdata =
-        canonicalize(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data")).unwrap();
+        canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data")).unwrap();
     let compiled = compile_project_with_options(
         Some(foundry_compilers_artifacts::Severity::Warning),
         Some(vec![testdata]),
@@ -2904,7 +2903,7 @@ fn can_install_solc_and_compile_version() {
     project
         .add_source(
             "Contract",
-            format!(
+            &format!(
                 r#"
 pragma solidity {version};
 contract Contract {{ }}
@@ -2924,7 +2923,7 @@ async fn can_install_solc_and_compile_std_json_input_async() {
     let tmp = TempProject::<MultiCompiler>::dapptools_init().unwrap();
     tmp.assert_no_errors();
     let source = tmp.list_source_files().into_iter().find(|p| p.ends_with("Dapp.t.sol")).unwrap();
-    let input = tmp.project().standard_json_input(source).unwrap();
+    let input = tmp.project().standard_json_input(&source).unwrap();
     let solc = Solc::find_or_install(&Version::new(0, 8, 24)).unwrap();
 
     assert!(input.settings.remappings.contains(&"ds-test/=lib/ds-test/src/".parse().unwrap()));
@@ -3487,11 +3486,11 @@ fn can_handle_conflicting_files_recompile() {
     assert_eq!(artifact_files, expected_files);
 
     // ensure that `a.sol/A.json` is unchanged
-    let outer = artifacts.find("src/A.sol", "A").unwrap();
-    let outer_recompiled = recompiled_artifacts.find("src/A.sol", "A").unwrap();
+    let outer = artifacts.find("src/A.sol".as_ref(), "A").unwrap();
+    let outer_recompiled = recompiled_artifacts.find("src/A.sol".as_ref(), "A").unwrap();
     assert_eq!(outer, outer_recompiled);
 
-    let inner_recompiled = recompiled_artifacts.find("src/inner/A.sol", "A").unwrap();
+    let inner_recompiled = recompiled_artifacts.find("src/inner/A.sol".as_ref(), "A").unwrap();
     assert!(inner_recompiled.get_abi().unwrap().functions.contains_key("baz"));
 }
 
@@ -3584,11 +3583,11 @@ fn can_handle_conflicting_files_case_sensitive_recompile() {
     assert_eq!(artifact_files, expected_files);
 
     // ensure that `a.sol/A.json` is unchanged
-    let outer = artifacts.find("src/a.sol", "A").unwrap();
-    let outer_recompiled = recompiled_artifacts.find("src/a.sol", "A").unwrap();
+    let outer = artifacts.find("src/a.sol".as_ref(), "A").unwrap();
+    let outer_recompiled = recompiled_artifacts.find("src/a.sol".as_ref(), "A").unwrap();
     assert_eq!(outer, outer_recompiled);
 
-    let inner_recompiled = recompiled_artifacts.find("src/inner/A.sol", "A").unwrap();
+    let inner_recompiled = recompiled_artifacts.find("src/inner/A.sol".as_ref(), "A").unwrap();
     assert!(inner_recompiled.get_abi().unwrap().functions.contains_key("baz"));
 }
 
@@ -3842,8 +3841,8 @@ contract D {
 fn test_deterministic_metadata() {
     let tmp_dir = tempfile::tempdir().unwrap();
     let root = tmp_dir.path();
-    let orig_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
-    copy_dir_all(orig_root, &tmp_dir).unwrap();
+    let orig_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-sample");
+    copy_dir_all(&orig_root, tmp_dir.path()).unwrap();
 
     let paths = ProjectPathsConfig::builder().root(root).build().unwrap();
     let project = Project::builder()
@@ -3859,8 +3858,7 @@ fn test_deterministic_metadata() {
     let bytecode = artifact.bytecode.as_ref().unwrap().bytes().unwrap().clone();
     let expected_bytecode = Bytes::from_str(
         &std::fs::read_to_string(
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("../../test-data/dapp-test-bytecode.txt"),
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/dapp-test-bytecode.txt"),
         )
         .unwrap(),
     )
@@ -3874,9 +3872,9 @@ fn can_compile_vyper_with_cache() {
     let root = tmp_dir.path();
     let cache = root.join("cache").join(SOLIDITY_FILES_CACHE_FILENAME);
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let orig_root = manifest_dir.join("../../test-data/vyper-sample");
-    copy_dir_all(orig_root, &tmp_dir).unwrap();
+    copy_dir_all(&orig_root, tmp_dir.path()).unwrap();
 
     let paths = ProjectPathsConfig::builder()
         .cache(cache)
@@ -3916,7 +3914,7 @@ fn can_compile_vyper_with_cache() {
 
 #[test]
 fn yul_remappings_ignored() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/yul-sample");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/yul-sample");
     // Add dummy remapping.
     let paths = ProjectPathsConfig::builder().sources(root.clone()).remapping(Remapping {
         context: None,
@@ -3931,7 +3929,7 @@ fn yul_remappings_ignored() {
 
 #[test]
 fn test_vyper_imports() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/vyper-imports");
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/vyper-imports");
 
     let paths = ProjectPathsConfig::builder()
         .sources(root.join("src"))
@@ -3956,10 +3954,9 @@ fn test_vyper_imports() {
 
 #[test]
 fn test_can_compile_multi() {
-    let root = canonicalize(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../test-data/multi-sample"),
-    )
-    .unwrap();
+    let root =
+        canonicalize(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/multi-sample"))
+            .unwrap();
 
     let paths = ProjectPathsConfig::builder()
         .sources(root.join("src"))
@@ -3985,7 +3982,7 @@ fn test_can_compile_multi() {
         .unwrap();
 
     let compiled = project.compile().unwrap();
-    assert!(compiled.find(root.join("src/Counter.sol").to_string_lossy(), "Counter").is_some());
-    assert!(compiled.find(root.join("src/Counter.vy").to_string_lossy(), "Counter").is_some());
+    assert!(compiled.find(&root.join("src/Counter.sol"), "Counter").is_some());
+    assert!(compiled.find(&root.join("src/Counter.vy"), "Counter").is_some());
     compiled.assert_success();
 }


### PR DESCRIPTION
These mostly only bloat code size and compilation times, which are already not great when we are already codegenning a billion structs and ASTs with serde derives

For AsRef<str>, the only change is having to specify an extra 1 (one) character (&) when using `String` so it derefs to `str`, otherwise it's the same

For AsRef<Path> it's the same as AsRef<str> when using Path/PathBuf, but it's a bit worse for string literals; but most of these functions are called with variables in the first place. except in tests which will have to use .as_ref() or Path::new

I've not removed these when using with &[] or impl IntoIterator since that does help quite a bit, e.g if you have an owning iterator of Strings, you cannot borrow inside of a map closure

I've also kept Into<PathBuf> since that makes more sense, you want to avoid cloning if you can pass in an owned thing already, otherwise you'll clone it yourself

Also fixes some inconsistencies in function signatures for str vs path