### PR TITLE
feat: respect `paths.libraries` for Vyper

### DIFF
--- a/crates/artifacts/vyper/src/settings.rs
+++ b/crates/artifacts/vyper/src/settings.rs
@@ -2,7 +2,10 @@ use foundry_compilers_artifacts_solc::{
     output_selection::OutputSelection, serde_helpers, EvmVersion,
 };
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, Serialize, Clone, Copy, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -28,6 +31,8 @@ pub struct VyperSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bytecode_metadata: Option<bool>,
     pub output_selection: OutputSelection,
+    #[serde(rename = "search_paths", skip_serializing_if = "Option::is_none")]
+    pub search_paths: Option<BTreeSet<PathBuf>>,
 }
 
 impl VyperSettings {
@@ -48,6 +53,9 @@ impl VyperSettings {
                 })
                 .collect(),
         );
+        self.search_paths = self.search_paths.as_ref().map(|paths| {
+            paths.iter().map(|p| p.strip_prefix(base).unwrap_or(p.as_path()).into()).collect()
+        });
     }
 
     /// During caching we prune output selection for some of the sources, however, Vyper will reject

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -136,7 +136,14 @@ pub trait ParsedSource: Debug + Sized + Send + Clone {
 
     fn parse(content: &str, file: &Path) -> Result<Self>;
     fn version_req(&self) -> Option<&VersionReq>;
-    fn resolve_imports<C>(&self, paths: &ProjectPathsConfig<C>) -> Result<Vec<PathBuf>>;
+
+    /// Invoked during import resolution. Should resolve imports for the given source, and populate
+    /// include_paths for compilers which support this config.
+    fn resolve_imports<C>(
+        &self,
+        paths: &ProjectPathsConfig<C>,
+        include_paths: &mut BTreeSet<PathBuf>,
+    ) -> Result<Vec<PathBuf>>;
     fn language(&self) -> Self::Language;
 
     /// Used to configure [OutputSelection] for sparse builds. In certain cases, we might want to

--- a/crates/compilers/src/compilers/multi.rs
+++ b/crates/compilers/src/compilers/multi.rs
@@ -305,10 +305,14 @@ impl ParsedSource for MultiCompilerParsedSource {
         }
     }
 
-    fn resolve_imports<C>(&self, paths: &crate::ProjectPathsConfig<C>) -> Result<Vec<PathBuf>> {
+    fn resolve_imports<C>(
+        &self,
+        paths: &crate::ProjectPathsConfig<C>,
+        include_paths: &mut BTreeSet<PathBuf>,
+    ) -> Result<Vec<PathBuf>> {
         match self {
-            Self::Solc(parsed) => parsed.resolve_imports(paths),
-            Self::Vyper(parsed) => parsed.resolve_imports(paths),
+            Self::Solc(parsed) => parsed.resolve_imports(paths, include_paths),
+            Self::Vyper(parsed) => parsed.resolve_imports(paths, include_paths),
         }
     }
 

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -221,7 +221,11 @@ impl ParsedSource for SolData {
         self.version_req.as_ref()
     }
 
-    fn resolve_imports<C>(&self, _paths: &crate::ProjectPathsConfig<C>) -> Result<Vec<PathBuf>> {
+    fn resolve_imports<C>(
+        &self,
+        _paths: &crate::ProjectPathsConfig<C>,
+        _include_paths: &mut BTreeSet<PathBuf>,
+    ) -> Result<Vec<PathBuf>> {
         return Ok(self.imports.iter().map(|i| i.data().path().to_path_buf()).collect_vec());
     }
 

--- a/crates/compilers/src/compilers/vyper/input.rs
+++ b/crates/compilers/src/compilers/vyper/input.rs
@@ -6,7 +6,13 @@ use crate::{
 use foundry_compilers_artifacts::sources::{Source, Sources};
 use semver::Version;
 use serde::Serialize;
-use std::{borrow::Cow, path::Path};
+use std::{
+    borrow::Cow,
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+pub const VYPER_SEARCH_PATHS: Version = Version::new(0, 4, 0);
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VyperVersionedInput {
@@ -51,5 +57,12 @@ impl CompilerInput for VyperVersionedInput {
             .iter()
             .chain(self.input.interfaces.iter())
             .map(|(path, source)| (path.as_path(), source))
+    }
+
+    fn with_include_paths(mut self, include_paths: BTreeSet<PathBuf>) -> Self {
+        if self.version >= VYPER_SEARCH_PATHS {
+            self.input.settings.search_paths = Some(include_paths);
+        }
+        self
     }
 }

--- a/crates/compilers/src/compilers/vyper/settings.rs
+++ b/crates/compilers/src/compilers/vyper/settings.rs
@@ -14,6 +14,6 @@ impl CompilerSettings for VyperSettings {
             && optimize == &other.optimize
             && bytecode_metadata == &other.bytecode_metadata
             && output_selection.is_subset_of(&other.output_selection)
-            && search_paths == search_paths
+            && search_paths == &other.search_paths
     }
 }

--- a/crates/compilers/src/compilers/vyper/settings.rs
+++ b/crates/compilers/src/compilers/vyper/settings.rs
@@ -8,10 +8,12 @@ impl CompilerSettings for VyperSettings {
     }
 
     fn can_use_cached(&self, other: &Self) -> bool {
-        let Self { evm_version, optimize, bytecode_metadata, output_selection } = self;
+        let Self { evm_version, optimize, bytecode_metadata, output_selection, search_paths } =
+            self;
         evm_version == &other.evm_version
             && optimize == &other.optimize
             && bytecode_metadata == &other.bytecode_metadata
             && output_selection.is_subset_of(&other.output_selection)
+            && search_paths == search_paths
     }
 }

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -357,6 +357,7 @@ impl<D: ParsedSource> Graph<D> {
         // tracks additional paths that should be used with `--include-path`, these are libraries
         // that use absolute imports like `import "src/Contract.sol"`
         let mut resolved_solc_include_paths = BTreeSet::new();
+        resolved_solc_include_paths.insert(paths.root.clone());
 
         // keep track of all unique paths that we failed to resolve to not spam the reporter with
         // the same path
@@ -365,14 +366,14 @@ impl<D: ParsedSource> Graph<D> {
         // now we need to resolve all imports for the source file and those imported from other
         // locations
         while let Some((path, node)) = unresolved.pop_front() {
-            let mut resolved_imports = Vec::with_capacity(node.data.resolve_imports(paths)?.len());
+            let mut resolved_imports = Vec::new();
             // parent directory of the current file
             let cwd = match path.parent() {
                 Some(inner) => inner,
                 None => continue,
             };
 
-            for import_path in node.data.resolve_imports(paths)? {
+            for import_path in node.data.resolve_imports(paths, &mut resolved_solc_include_paths)? {
                 match paths.resolve_import_and_include_paths(
                     cwd,
                     &import_path,


### PR DESCRIPTION
Vyper 0.4 added `search_paths` key which is basically equivalent to solc's `include_paths` which we are already populating during import resolution.

Adds this key to compiler input and also tries going through `paths.libs` while resolving Vyper imports.

This allows users to normally configure dependencies outside of their `src` directory (i.e. from `venv/.../site-packages` or `lib`)