### PR TITLE
refactor: unify sources and filtered sources

### DIFF
--- a/crates/artifacts/solc/src/configurable.rs
+++ b/crates/artifacts/solc/src/configurable.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Ast, CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
+    CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
     CompactDeployedBytecode, DevDoc, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource,
     Metadata, Offsets, SourceFile, StorageLayout, UserDoc,
 };
@@ -49,7 +49,7 @@ pub struct ConfigurableContractArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ewasm: Option<Ewasm>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ast: Option<Ast>,
+    pub ast: Option<RawValueWrapper>,
     /// The identifier of the source file
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<u32>,
@@ -105,5 +105,32 @@ impl<'a> From<&'a ConfigurableContractArtifact> for CompactContractBytecodeCow<'
             bytecode: artifact.bytecode.as_ref().map(Cow::Borrowed),
             deployed_bytecode: artifact.deployed_bytecode.as_ref().map(Cow::Borrowed),
         }
+    }
+}
+
+/// A wrapper around `serde_json::value::RawValue` to allow for `PartialEq` and `Eq`
+/// implementations.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RawValueWrapper(pub Box<serde_json::value::RawValue>);
+
+impl PartialEq for RawValueWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.get().eq(other.0.get())
+    }
+}
+
+impl Eq for RawValueWrapper {}
+
+impl std::ops::Deref for RawValueWrapper {
+    type Target = serde_json::value::RawValue;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl std::ops::DerefMut for RawValueWrapper {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
     }
 }

--- a/crates/artifacts/solc/src/configurable.rs
+++ b/crates/artifacts/solc/src/configurable.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
+    Ast, CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
     CompactDeployedBytecode, DevDoc, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource,
     Metadata, Offsets, SourceFile, StorageLayout, UserDoc,
 };
@@ -49,7 +49,7 @@ pub struct ConfigurableContractArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ewasm: Option<Ewasm>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ast: Option<RawValueWrapper>,
+    pub ast: Option<Ast>,
     /// The identifier of the source file
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<u32>,
@@ -105,32 +105,5 @@ impl<'a> From<&'a ConfigurableContractArtifact> for CompactContractBytecodeCow<'
             bytecode: artifact.bytecode.as_ref().map(Cow::Borrowed),
             deployed_bytecode: artifact.deployed_bytecode.as_ref().map(Cow::Borrowed),
         }
-    }
-}
-
-/// A wrapper around `serde_json::value::RawValue` to allow for `PartialEq` and `Eq`
-/// implementations.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RawValueWrapper(pub Box<serde_json::value::RawValue>);
-
-impl PartialEq for RawValueWrapper {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.get().eq(other.0.get())
-    }
-}
-
-impl Eq for RawValueWrapper {}
-
-impl std::ops::Deref for RawValueWrapper {
-    type Target = serde_json::value::RawValue;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.deref()
-    }
-}
-
-impl std::ops::DerefMut for RawValueWrapper {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.0.deref_mut()
     }
 }

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1834,16 +1834,14 @@ pub struct StorageType {
 pub struct SourceFile {
     pub id: u32,
     #[serde(default, with = "serde_helpers::empty_json_object_opt")]
-    pub ast: Option<Ast>,
+    pub ast: Option<RawValueWrapper>,
 }
 
 impl SourceFile {
     /// Returns `true` if the source file contains at least 1 `ContractDefinition` such as
     /// `contract`, `abstract contract`, `interface` or `library`.
     pub fn contains_contract_definition(&self) -> bool {
-        self.ast.as_ref().is_some_and(|ast| {
-            ast.nodes.iter().any(|node| matches!(node.node_type, NodeType::ContractDefinition))
-        })
+        self.ast.as_ref().is_some_and(|s| s.get().contains("ContractDefinition"))
     }
 }
 

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1834,7 +1834,7 @@ pub struct StorageType {
 pub struct SourceFile {
     pub id: u32,
     #[serde(default, with = "serde_helpers::empty_json_object_opt")]
-    pub ast: Option<RawValueWrapper>,
+    pub ast: Option<Ast>,
 }
 
 impl PartialEq for SourceFile {
@@ -1849,7 +1849,9 @@ impl SourceFile {
     /// Returns `true` if the source file contains at least 1 `ContractDefinition` such as
     /// `contract`, `abstract contract`, `interface` or `library`.
     pub fn contains_contract_definition(&self) -> bool {
-        self.ast.as_ref().is_some_and(|s| s.get().contains("ContractDefinition"))
+        self.ast.as_ref().is_some_and(|ast| {
+            ast.nodes.iter().any(|node| matches!(node.node_type, NodeType::ContractDefinition))
+        })
     }
 }
 

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -106,8 +106,8 @@ impl SolcInput {
     /// Builds one or two inputs from given sources set. Returns two inputs in cases when there are
     /// both Solidity and Yul sources.
     pub fn resolve_and_build(sources: Sources, settings: Settings) -> Vec<Self> {
-        let mut solidity_sources = BTreeMap::new();
-        let mut yul_sources = BTreeMap::new();
+        let mut solidity_sources = Sources::new();
+        let mut yul_sources = Sources::new();
 
         for (file, source) in sources {
             if file.extension().map_or(false, |e| e == "yul") {

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1830,12 +1830,20 @@ pub struct StorageType {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourceFile {
     pub id: u32,
     #[serde(default, with = "serde_helpers::empty_json_object_opt")]
     pub ast: Option<RawValueWrapper>,
 }
+
+impl PartialEq for SourceFile {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for SourceFile {}
 
 impl SourceFile {
     /// Returns `true` if the source file contains at least 1 `ContractDefinition` such as

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1830,20 +1830,12 @@ pub struct StorageType {
     pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SourceFile {
     pub id: u32,
     #[serde(default, with = "serde_helpers::empty_json_object_opt")]
     pub ast: Option<Ast>,
 }
-
-impl PartialEq for SourceFile {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for SourceFile {}
 
 impl SourceFile {
     /// Returns `true` if the source file contains at least 1 `ContractDefinition` such as

--- a/crates/artifacts/solc/src/sources.rs
+++ b/crates/artifacts/solc/src/sources.rs
@@ -9,8 +9,97 @@ use std::{
     sync::Arc,
 };
 
-/// An ordered list of files and their source
-pub type Sources = BTreeMap<PathBuf, Source>;
+type SourcesInner = BTreeMap<PathBuf, Source>;
+
+/// An ordered list of files and their source.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Sources(pub SourcesInner);
+
+impl Sources {
+    /// Returns a new instance of [Sources].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` if no sources should have optimized output selection.
+    pub fn all_dirty(&self) -> bool {
+        self.0.values().all(|s| s.is_dirty())
+    }
+
+    /// Returns all entries that should not be optimized.
+    pub fn dirty(&self) -> impl Iterator<Item = (&PathBuf, &Source)> + '_ {
+        self.0.iter().filter(|(_, s)| s.is_dirty())
+    }
+
+    /// Returns all entries that should be optimized.
+    pub fn clean(&self) -> impl Iterator<Item = (&PathBuf, &Source)> + '_ {
+        self.0.iter().filter(|(_, s)| !s.is_dirty())
+    }
+
+    /// Returns all files that should not be optimized.
+    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + '_ {
+        self.dirty().map(|(k, _)| k)
+    }
+}
+
+impl std::ops::Deref for Sources {
+    type Target = SourcesInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Sources {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<I> From<I> for Sources
+where
+    SourcesInner: From<I>,
+{
+    fn from(value: I) -> Self {
+        Self(From::from(value))
+    }
+}
+
+impl<I> FromIterator<I> for Sources
+where
+    SourcesInner: FromIterator<I>,
+{
+    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+        Self(FromIterator::from_iter(iter))
+    }
+}
+
+impl IntoIterator for Sources {
+    type Item = <SourcesInner as IntoIterator>::Item;
+    type IntoIter = <SourcesInner as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Sources {
+    type Item = <&'a SourcesInner as IntoIterator>::Item;
+    type IntoIter = <&'a SourcesInner as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Sources {
+    type Item = <&'a mut SourcesInner as IntoIterator>::Item;
+    type IntoIter = <&'a mut SourcesInner as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
 
 /// Content of a solidity file
 ///
@@ -23,12 +112,14 @@ pub struct Source {
     /// conflicting versions then the same [Source] may be required by conflicting versions and
     /// needs to be duplicated.
     pub content: Arc<String>,
+    #[serde(skip, default)]
+    pub kind: SourceCompilationKind,
 }
 
 impl Source {
     /// Creates a new instance of [Source] with the given content.
     pub fn new(content: impl Into<String>) -> Self {
-        Self { content: Arc::new(content.into()) }
+        Self { content: Arc::new(content.into()), kind: SourceCompilationKind::Complete }
     }
 
     /// Reads the file's content
@@ -44,6 +135,11 @@ impl Source {
         }
 
         Ok(Self::new(content))
+    }
+
+    /// Returns `true` if the source should be compiled with full output selection.
+    pub fn is_dirty(&self) -> bool {
+        self.kind.is_dirty()
     }
 
     /// Recursively finds all source files under the given dir path and reads them all
@@ -95,7 +191,8 @@ impl Source {
             .par_bridge()
             .map(Into::into)
             .map(|file| Self::read(&file).map(|source| (file, source)))
-            .collect()
+            .collect::<Result<BTreeMap<_, _>, _>>()
+            .map(Sources)
     }
 
     /// Generate a non-cryptographically secure checksum of the file's content
@@ -158,5 +255,23 @@ impl AsRef<str> for Source {
 impl AsRef<[u8]> for Source {
     fn as_ref(&self) -> &[u8] {
         self.content.as_bytes()
+    }
+}
+
+/// Represents the state of a filtered [`Source`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum SourceCompilationKind {
+    /// We need a complete compilation output for the source.
+    #[default]
+    Complete,
+    /// A source for which we don't need a complete output and want to optimize its compilation by
+    /// reducing output selection.
+    Optimized,
+}
+
+impl SourceCompilationKind {
+    /// Whether this file should be compiled with full output selection
+    pub fn is_dirty(&self) -> bool {
+        matches!(self, Self::Complete)
     }
 }

--- a/crates/compilers/src/buildinfo.rs
+++ b/crates/compilers/src/buildinfo.rs
@@ -128,18 +128,16 @@ impl<L: Language> RawBuildInfo<L> {
 
 #[cfg(test)]
 mod tests {
-    use foundry_compilers_artifacts::{sources::Source, Error, SolcLanguage};
-
-    use crate::compilers::solc::SolcVersionedInput;
-
     use super::*;
-    use std::{collections::BTreeMap, path::PathBuf};
+    use crate::compilers::solc::SolcVersionedInput;
+    use foundry_compilers_artifacts::{sources::Source, Error, SolcLanguage, Sources};
+    use std::path::PathBuf;
 
     #[test]
     fn build_info_serde() {
         let v: Version = "0.8.4+commit.c7e474f2".parse().unwrap();
         let input = SolcVersionedInput::build(
-            BTreeMap::from([(PathBuf::from("input.sol"), Source::new(""))]),
+            Sources::from([(PathBuf::from("input.sol"), Source::new(""))]),
             Default::default(),
             SolcLanguage::Solidity,
             v,

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -5,8 +5,8 @@ use crate::{
     compilers::{Compiler, CompilerSettings, Language},
     output::Builds,
     resolver::GraphEdges,
-    ArtifactFile, ArtifactOutput, Artifacts, ArtifactsMap, FilteredSources, Graph, OutputContext,
-    Project, ProjectPaths, ProjectPathsConfig, SourceCompilationKind,
+    ArtifactFile, ArtifactOutput, Artifacts, ArtifactsMap, Graph, OutputContext, Project,
+    ProjectPaths, ProjectPathsConfig, SourceCompilationKind,
 };
 use foundry_compilers_artifacts::{
     sources::{Source, Sources},
@@ -668,10 +668,10 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
     /// 2. [SourceCompilationKind::Optimized] - the file is not dirty, but is imported by a dirty
     ///    file and thus will be processed by solc. For such files we don't need full data, so we
     ///    are marking them as clean to optimize output selection later.
-    fn filter(&mut self, sources: Sources, version: &Version) -> FilteredSources {
+    fn filter(&mut self, sources: &mut Sources, version: &Version) {
         // sources that should be passed to compiler.
-        let mut compile_complete = BTreeSet::new();
-        let mut compile_optimized = BTreeSet::new();
+        let mut compile_complete = HashSet::new();
+        let mut compile_optimized = HashSet::new();
 
         for (file, source) in sources.iter() {
             self.sources_in_scope.insert(file.clone(), version.clone());
@@ -697,20 +697,16 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
             }
         }
 
-        let filtered = sources
-            .into_iter()
-            .filter_map(|(file, source)| {
-                if compile_complete.contains(&file) {
-                    Some((file, SourceCompilationKind::Complete(source)))
-                } else if compile_optimized.contains(&file) {
-                    Some((file, SourceCompilationKind::Optimized(source)))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        FilteredSources(filtered)
+        sources.retain(|file, source| {
+            source.kind = if compile_complete.contains(file) {
+                SourceCompilationKind::Complete
+            } else if compile_optimized.contains(file) {
+                SourceCompilationKind::Optimized
+            } else {
+                return false;
+            };
+            true
+        });
     }
 
     /// Returns whether we are missing artifacts for the given file and version.
@@ -766,7 +762,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
         // Iterate over existing cache entries.
         let files = self.cache.files.keys().cloned().collect::<HashSet<_>>();
 
-        let mut sources = BTreeMap::new();
+        let mut sources = Sources::new();
 
         // Read all sources, marking entries as dirty on I/O errors.
         for file in &files {
@@ -959,14 +955,14 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
     // only useful for debugging for debugging purposes
     pub fn as_cached(&self) -> Option<&ArtifactsCacheInner<'a, T, C>> {
         match self {
-            ArtifactsCache::Ephemeral(_, _) => None,
+            ArtifactsCache::Ephemeral(..) => None,
             ArtifactsCache::Cached(cached) => Some(cached),
         }
     }
 
     pub fn output_ctx(&self) -> OutputContext<'_> {
         match self {
-            ArtifactsCache::Ephemeral(_, _) => Default::default(),
+            ArtifactsCache::Ephemeral(..) => Default::default(),
             ArtifactsCache::Cached(inner) => OutputContext::new(&inner.cache),
         }
     }
@@ -981,15 +977,15 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCache<'a, T, C> {
     /// Adds the file's hashes to the set if not set yet
     pub fn remove_dirty_sources(&mut self) {
         match self {
-            ArtifactsCache::Ephemeral(_, _) => {}
+            ArtifactsCache::Ephemeral(..) => {}
             ArtifactsCache::Cached(cache) => cache.find_and_remove_dirty(),
         }
     }
 
     /// Filters out those sources that don't need to be compiled
-    pub fn filter(&mut self, sources: Sources, version: &Version) -> FilteredSources {
+    pub fn filter(&mut self, sources: &mut Sources, version: &Version) {
         match self {
-            ArtifactsCache::Ephemeral(_, _) => sources.into(),
+            ArtifactsCache::Ephemeral(..) => {}
             ArtifactsCache::Cached(cache) => cache.filter(sources, version),
         }
     }

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -357,7 +357,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsState<'a, T, C> {
 }
 
 /// Determines how the `solc <-> sources` pairs are executed
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 enum CompilerSources<L> {
     /// Compile all these sequentially
     Sequential(VersionedSources<L>),

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -375,23 +375,16 @@ impl<L: Language> CompilerSources<L> {
         {
             use path_slash::PathBufExt;
 
-            fn slash_versioned_sources<L: Language>(v: &mut VersionedSources<L>) {
-                v.values_mut().for_each(|versioned_sources| {
-                    versioned_sources.values_mut().for_each(|sources| {
-                        *sources = std::mem::take(sources)
-                            .into_iter()
-                            .map(|(path, source)| {
-                                (PathBuf::from(path.to_slash_lossy().as_ref()), source)
-                            })
-                            .collect()
-                    })
-                });
-            }
-
-            match self {
-                CompilerSources::Sequential(v) => slash_versioned_sources(v),
-                CompilerSources::Parallel(v, _) => slash_versioned_sources(v),
-            };
+            self.sources.values_mut().for_each(|versioned_sources| {
+                versioned_sources.values_mut().for_each(|sources| {
+                    *sources = std::mem::take(sources)
+                        .into_iter()
+                        .map(|(path, source)| {
+                            (PathBuf::from(path.to_slash_lossy().as_ref()), source)
+                        })
+                        .collect()
+                })
+            });
         }
     }
 

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -356,18 +356,17 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsState<'a, T, C> {
     }
 }
 
-/// Determines how the `solc <-> sources` pairs are executed
+/// Determines how the `solc <-> sources` pairs are executed.
 #[derive(Debug, Clone)]
-enum CompilerSources<L> {
-    /// Compile all these sequentially
-    Sequential(VersionedSources<L>),
-    /// Compile all these in parallel using a certain amount of jobs
-    #[allow(dead_code)]
-    Parallel(VersionedSources<L>, usize),
+struct CompilerSources<L> {
+    /// The sources to compile.
+    sources: VersionedSources<L>,
+    /// The number of jobs to use for parallel compilation.
+    jobs: Option<usize>,
 }
 
 impl<L: Language> CompilerSources<L> {
-    /// Converts all `\\` separators to `/`
+    /// Converts all `\\` separators to `/`.
     ///
     /// This effectively ensures that `solc` can find imported files like `/src/Cheats.sol` in the
     /// VFS (the `CompilerInput` as json) under `src/Cheats.sol`.

--- a/crates/compilers/src/filter.rs
+++ b/crates/compilers/src/filter.rs
@@ -3,12 +3,12 @@
 use crate::{
     compilers::{multi::MultiCompilerParsedSource, CompilerSettings, ParsedSource},
     resolver::{parse::SolData, GraphEdges},
-    Source, Sources,
+    Sources,
 };
 use foundry_compilers_artifacts::output_selection::OutputSelection;
 use std::{
-    collections::{BTreeMap, HashSet},
-    fmt::{self, Formatter},
+    collections::HashSet,
+    fmt,
     path::{Path, PathBuf},
 };
 
@@ -33,13 +33,13 @@ pub struct TestFileFilter {
 }
 
 impl fmt::Debug for TestFileFilter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TestFileFilter").finish()
     }
 }
 
 impl fmt::Display for TestFileFilter {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("TestFileFilter")
     }
 }
@@ -69,7 +69,7 @@ impl MaybeSolData for MultiCompilerParsedSource {
     }
 }
 
-/// A type that can apply a filter to a set of preprocessed [FilteredSources] in order to set sparse
+/// A type that can apply a filter to a set of preprocessed [Sources] in order to set sparse
 /// output for specific files
 #[derive(Default)]
 pub enum SparseOutputFilter<'a> {
@@ -79,7 +79,7 @@ pub enum SparseOutputFilter<'a> {
     /// _dirty_.
     #[default]
     Optimized,
-    /// Apply an additional filter to [FilteredSources] to
+    /// Apply an additional filter to [Sources] to
     Custom(&'a dyn FileFilter),
 }
 
@@ -103,7 +103,7 @@ impl<'a> SparseOutputFilter<'a> {
     /// filter matches depend on libraries that need to be linked
     pub fn sparse_sources<D: ParsedSource, S: CompilerSettings>(
         &self,
-        sources: FilteredSources,
+        sources: Sources,
         settings: &mut S,
         graph: &GraphEdges<D>,
     ) -> (Sources, Vec<PathBuf>) {
@@ -170,107 +170,10 @@ impl<'a> SparseOutputFilter<'a> {
 }
 
 impl<'a> fmt::Debug for SparseOutputFilter<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SparseOutputFilter::Optimized => f.write_str("Optimized"),
             SparseOutputFilter::Custom(_) => f.write_str("Custom"),
         }
-    }
-}
-
-/// Container type for a mapping from source path to [SourceCompilationKind]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FilteredSources(pub BTreeMap<PathBuf, SourceCompilationKind>);
-
-impl FilteredSources {
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if no sources should have optimized output selection.
-    pub fn all_dirty(&self) -> bool {
-        self.0.values().all(|s| s.is_dirty())
-    }
-
-    /// Returns all entries that should not be optimized.
-    pub fn dirty(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
-        self.0.iter().filter(|(_, s)| s.is_dirty())
-    }
-
-    /// Returns all entries that should be optimized.
-    pub fn clean(&self) -> impl Iterator<Item = (&PathBuf, &SourceCompilationKind)> + '_ {
-        self.0.iter().filter(|(_, s)| !s.is_dirty())
-    }
-
-    /// Returns all files that should not be optimized.
-    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
-        self.0.iter().filter_map(|(k, s)| s.is_dirty().then_some(k))
-    }
-}
-
-impl From<FilteredSources> for Sources {
-    fn from(sources: FilteredSources) -> Self {
-        sources.0.into_iter().map(|(k, v)| (k, v.into_source())).collect()
-    }
-}
-
-impl From<Sources> for FilteredSources {
-    fn from(s: Sources) -> Self {
-        Self(s.into_iter().map(|(key, val)| (key, SourceCompilationKind::Complete(val))).collect())
-    }
-}
-
-impl From<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
-    fn from(s: BTreeMap<PathBuf, SourceCompilationKind>) -> Self {
-        Self(s)
-    }
-}
-
-impl AsRef<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
-    fn as_ref(&self) -> &BTreeMap<PathBuf, SourceCompilationKind> {
-        &self.0
-    }
-}
-
-impl AsMut<BTreeMap<PathBuf, SourceCompilationKind>> for FilteredSources {
-    fn as_mut(&mut self) -> &mut BTreeMap<PathBuf, SourceCompilationKind> {
-        &mut self.0
-    }
-}
-
-/// Represents the state of a filtered [Source]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SourceCompilationKind {
-    /// We need a complete compilation output for the source.
-    Complete(Source),
-    /// A source for which we don't need a complete output and want to optimize its compilation by
-    /// reducing output selection.
-    Optimized(Source),
-}
-
-impl SourceCompilationKind {
-    /// Returns the underlying source
-    pub fn source(&self) -> &Source {
-        match self {
-            Self::Complete(s) => s,
-            Self::Optimized(s) => s,
-        }
-    }
-
-    /// Consumes the type and returns the underlying source
-    pub fn into_source(self) -> Source {
-        match self {
-            Self::Complete(s) => s,
-            Self::Optimized(s) => s,
-        }
-    }
-
-    /// Whether this file should be compiled with full output selection
-    pub fn is_dirty(&self) -> bool {
-        matches!(self, Self::Complete(_))
     }
 }

--- a/crates/compilers/src/filter.rs
+++ b/crates/compilers/src/filter.rs
@@ -103,10 +103,10 @@ impl<'a> SparseOutputFilter<'a> {
     /// filter matches depend on libraries that need to be linked
     pub fn sparse_sources<D: ParsedSource, S: CompilerSettings>(
         &self,
-        sources: Sources,
+        sources: &Sources,
         settings: &mut S,
         graph: &GraphEdges<D>,
-    ) -> (Sources, Vec<PathBuf>) {
+    ) -> Vec<PathBuf> {
         let mut full_compilation: HashSet<PathBuf> = sources
             .dirty_files()
             .flat_map(|file| {
@@ -165,7 +165,7 @@ impl<'a> SparseOutputFilter<'a> {
             }
         });
 
-        (sources.into(), full_compilation.into_iter().collect())
+        full_compilation.into_iter().collect()
     }
 }
 

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -34,9 +34,7 @@ mod config;
 pub use config::{PathStyle, ProjectPaths, ProjectPathsConfig, SolcConfig};
 
 mod filter;
-pub use filter::{
-    FileFilter, FilteredSources, SourceCompilationKind, SparseOutputFilter, TestFileFilter,
-};
+pub use filter::{FileFilter, SparseOutputFilter, TestFileFilter};
 
 pub mod report;
 
@@ -53,7 +51,7 @@ use compilers::multi::MultiCompiler;
 use derivative::Derivative;
 use foundry_compilers_artifacts::solc::{
     output_selection::OutputSelection,
-    sources::{Source, Sources},
+    sources::{Source, SourceCompilationKind, Sources},
     Contract, Settings, Severity, SourceFile, StandardJsonCompilerInput,
 };
 use foundry_compilers_core::error::{Result, SolcError, SolcIoError};

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -336,6 +336,7 @@ impl<D: ParsedSource> Graph<D> {
         // we start off by reading all input files, which includes all solidity files from the
         // source and test folder
         let mut unresolved: VecDeque<_> = sources
+            .0
             .into_par_iter()
             .map(|(path, source)| {
                 let data = D::parse(source.as_ref(), &path)?;


### PR DESCRIPTION
Allows reusing resources and just doing `retain` instead of `.into_iter().collect()` on 3 nested maps