### PR TITLE
chore: improve stripping file prefixes

### DIFF
--- a/crates/artifacts/solc/src/bytecode.rs
+++ b/crates/artifacts/solc/src/bytecode.rs
@@ -384,9 +384,7 @@ where
 {
     match bytecode {
         BytecodeObject::Bytecode(code) => s.serialize_str(&hex::encode(code)),
-        BytecodeObject::Unlinked(code) => {
-            s.serialize_str(code.strip_prefix("0x").unwrap_or(code.as_str()))
-        }
+        BytecodeObject::Unlinked(code) => s.serialize_str(code.strip_prefix("0x").unwrap_or(code)),
     }
 }
 

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -38,8 +38,8 @@ use crate::output_selection::{ContractOutputSelection, OutputSelection};
 use foundry_compilers_core::{
     error::SolcError,
     utils::{
-        BERLIN_SOLC, BYZANTIUM_SOLC, CANCUN_SOLC, CONSTANTINOPLE_SOLC, ISTANBUL_SOLC, LONDON_SOLC,
-        PARIS_SOLC, PETERSBURG_SOLC, SHANGHAI_SOLC,
+        strip_prefix_owned, BERLIN_SOLC, BYZANTIUM_SOLC, CANCUN_SOLC, CONSTANTINOPLE_SOLC,
+        ISTANBUL_SOLC, LONDON_SOLC, PARIS_SOLC, PETERSBURG_SOLC, SHANGHAI_SOLC,
     },
 };
 pub use serde_helpers::{deserialize_bytes, deserialize_opt_bytes};
@@ -167,7 +167,7 @@ impl SolcInput {
     pub fn strip_prefix(&mut self, base: &Path) {
         self.sources = std::mem::take(&mut self.sources)
             .into_iter()
-            .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
+            .map(|(path, s)| (strip_prefix_owned(path, base), s))
             .collect();
 
         self.settings.strip_prefix(base);
@@ -505,7 +505,7 @@ impl Settings {
                     (
                         Path::new(&file)
                             .strip_prefix(base)
-                            .map(|p| format!("{}", p.display()))
+                            .map(|p| p.display().to_string())
                             .unwrap_or(file),
                         selection,
                     )
@@ -521,7 +521,7 @@ impl Settings {
                     (
                         Path::new(&path)
                             .strip_prefix(base)
-                            .map(|p| format!("{}", p.display()))
+                            .map(|p| p.display().to_string())
                             .unwrap_or(path),
                         contracts,
                     )

--- a/crates/artifacts/solc/src/remappings.rs
+++ b/crates/artifacts/solc/src/remappings.rs
@@ -68,7 +68,7 @@ impl Remapping {
     /// Removes the `base` path from the remapping
     pub fn strip_prefix(&mut self, base: &Path) -> &mut Self {
         if let Ok(stripped) = Path::new(&self.path).strip_prefix(base) {
-            self.path = format!("{}", stripped.display());
+            self.path = stripped.display().to_string();
         }
         self
     }
@@ -356,7 +356,7 @@ impl fmt::Display for RelativeRemapping {
 impl From<RelativeRemapping> for Remapping {
     fn from(r: RelativeRemapping) -> Self {
         let RelativeRemapping { context, mut name, path } = r;
-        let mut path = format!("{}", path.relative().display());
+        let mut path = path.relative().display().to_string();
         if !path.ends_with('/') {
             path.push('/');
         }

--- a/crates/artifacts/vyper/Cargo.toml
+++ b/crates/artifacts/vyper/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 foundry-compilers-artifacts-solc.workspace = true
+foundry-compilers-core.workspace = true
 
 serde.workspace = true
 alloy-primitives.workspace = true

--- a/crates/artifacts/vyper/src/input.rs
+++ b/crates/artifacts/vyper/src/input.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
-
 use super::VyperSettings;
 use foundry_compilers_artifacts_solc::sources::Sources;
+use foundry_compilers_core::utils::strip_prefix_owned;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// Extension of Vyper interface file.
 pub const VYPER_INTERFACE_EXTENSION: &str = "vyi";
@@ -37,12 +37,12 @@ impl VyperInput {
     pub fn strip_prefix(&mut self, base: &Path) {
         self.sources = std::mem::take(&mut self.sources)
             .into_iter()
-            .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
+            .map(|(path, s)| (strip_prefix_owned(path, base), s))
             .collect();
 
         self.interfaces = std::mem::take(&mut self.interfaces)
             .into_iter()
-            .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
+            .map(|(path, s)| (strip_prefix_owned(path, base), s))
             .collect();
 
         self.settings.strip_prefix(base)

--- a/crates/artifacts/vyper/src/settings.rs
+++ b/crates/artifacts/vyper/src/settings.rs
@@ -44,7 +44,7 @@ impl VyperSettings {
                     (
                         Path::new(&file)
                             .strip_prefix(base)
-                            .map(|p| format!("{}", p.display()))
+                            .map(|p| p.display().to_string())
                             .unwrap_or(file),
                         selection,
                     )

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -14,7 +14,7 @@ use foundry_compilers_artifacts::{
 };
 use foundry_compilers_core::{
     error::{Result, SolcError},
-    utils,
+    utils::{self, strip_prefix},
 };
 use semver::Version;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -619,14 +619,14 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
             .edges
             .imports(&file)
             .into_iter()
-            .map(|import| utils::source_name(import, self.project.root()).to_path_buf())
+            .map(|import| strip_prefix(import, self.project.root()).into())
             .collect();
 
         let entry = CacheEntry {
             last_modification_date: CacheEntry::<C::Settings>::read_last_modification_date(&file)
                 .unwrap_or_default(),
             content_hash: source.content_hash(),
-            source_name: utils::source_name(&file, self.project.root()).into(),
+            source_name: strip_prefix(&file, self.project.root()).into(),
             compiler_settings: self.project.settings.clone(),
             imports,
             version_requirement: self.edges.version_requirement(&file).map(|v| v.to_string()),

--- a/crates/compilers/src/compile/output/sources.rs
+++ b/crates/compilers/src/compile/output/sources.rs
@@ -1,4 +1,5 @@
 use crate::SourceFile;
+use foundry_compilers_core::utils::strip_prefix_owned;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -194,9 +195,7 @@ impl VersionedSourceFiles {
     pub fn strip_prefix_all(&mut self, base: &Path) -> &mut Self {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
-            .map(|(file_path, sources)| {
-                (file_path.strip_prefix(base).unwrap_or(&file_path).to_path_buf(), sources)
-            })
+            .map(|(file, sources)| (strip_prefix_owned(file, base), sources))
             .collect();
         self
     }

--- a/crates/compilers/src/config.rs
+++ b/crates/compilers/src/config.rs
@@ -13,7 +13,7 @@ use foundry_compilers_artifacts::{
 };
 use foundry_compilers_core::{
     error::{Result, SolcError, SolcIoError},
-    utils,
+    utils::{self, strip_prefix_owned},
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -661,27 +661,25 @@ impl ProjectPaths {
 
     /// Removes `base` from all folders
     pub fn strip_prefix_all(&mut self, base: &Path) -> &mut Self {
-        if let Ok(prefix) = self.artifacts.strip_prefix(base) {
-            self.artifacts = prefix.to_path_buf();
+        if let Ok(stripped) = self.artifacts.strip_prefix(base) {
+            self.artifacts = stripped.to_path_buf();
         }
-        if let Ok(prefix) = self.build_infos.strip_prefix(base) {
-            self.build_infos = prefix.to_path_buf();
+        if let Ok(stripped) = self.build_infos.strip_prefix(base) {
+            self.build_infos = stripped.to_path_buf();
         }
-        if let Ok(prefix) = self.sources.strip_prefix(base) {
-            self.sources = prefix.to_path_buf();
+        if let Ok(stripped) = self.sources.strip_prefix(base) {
+            self.sources = stripped.to_path_buf();
         }
-        if let Ok(prefix) = self.tests.strip_prefix(base) {
-            self.tests = prefix.to_path_buf();
+        if let Ok(stripped) = self.tests.strip_prefix(base) {
+            self.tests = stripped.to_path_buf();
         }
-        if let Ok(prefix) = self.scripts.strip_prefix(base) {
-            self.scripts = prefix.to_path_buf();
+        if let Ok(stripped) = self.scripts.strip_prefix(base) {
+            self.scripts = stripped.to_path_buf();
         }
-        let libraries = std::mem::take(&mut self.libraries);
-        self.libraries.extend(
-            libraries
-                .into_iter()
-                .map(|p| p.strip_prefix(base).map(|p| p.to_path_buf()).unwrap_or(p)),
-        );
+        self.libraries = std::mem::take(&mut self.libraries)
+            .into_iter()
+            .map(|path| strip_prefix_owned(path, base))
+            .collect();
         self
     }
 }

--- a/crates/compilers/src/filter.rs
+++ b/crates/compilers/src/filter.rs
@@ -156,12 +156,13 @@ impl<'a> SparseOutputFilter<'a> {
 
             // set output selections
             for file in sources.0.keys() {
-                let key = format!("{}", file.display());
-                if full_compilation.contains(file) {
-                    selection.as_mut().insert(key, default_selection.clone());
+                let key = file.display().to_string();
+                let output = if full_compilation.contains(file) {
+                    default_selection.clone()
                 } else {
-                    selection.as_mut().insert(key, OutputSelection::empty_file_output_select());
-                }
+                    OutputSelection::empty_file_output_select()
+                };
+                selection.as_mut().insert(key, output);
             }
         });
 

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -210,7 +210,17 @@ pub fn solidity_dirs(root: &Path) -> Vec<PathBuf> {
 ///
 /// `/Users/project/sources/contract.sol` -> `sources/contracts.sol`
 pub fn source_name<'a>(source: &'a Path, root: &Path) -> &'a Path {
+    strip_prefix(source, root)
+}
+
+/// Strips `root` from `source` and returns the relative path.
+pub fn strip_prefix<'a>(source: &'a Path, root: &Path) -> &'a Path {
     source.strip_prefix(root).unwrap_or(source)
+}
+
+/// Strips `root` from `source` and returns the relative path.
+pub fn strip_prefix_owned(source: PathBuf, root: &Path) -> PathBuf {
+    source.strip_prefix(root).map(Path::to_path_buf).unwrap_or(source)
 }
 
 /// Attempts to determine if the given source is a local, relative import.


### PR DESCRIPTION
Use utils to avoid allocations, add stripping methods to ArtifactId for https://github.com/foundry-rs/foundry/pull/8294