### PR TITLE
fix: allow empty modifier body in AST

### DIFF
--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -1000,7 +1000,7 @@ ast_node!(
         name_location: Option<SourceLocation>,
         #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         base_modifiers: Vec<usize>,
-        body: Block,
+        body: Option<Block>,
         documentation: Option<StructuredDocumentation>,
         overrides: Option<OverrideSpecifier>,
         parameters: ParameterList,

--- a/crates/artifacts/solc/src/ast/visitor.rs
+++ b/crates/artifacts/solc/src/ast/visitor.rs
@@ -281,7 +281,9 @@ impl_walk!(StructDefinition, visit_struct_definition, |struct_, visitor| {
 });
 
 impl_walk!(ModifierDefinition, visit_modifier_definition, |modifier, visitor| {
-    modifier.body.walk(visitor);
+    if let Some(body) = &modifier.body {
+        body.walk(visitor);
+    }
     if let Some(override_) = &modifier.overrides {
         override_.walk(visitor);
     }


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/7554

solc since 0.6.7 allows empty `body` on modifiers

this was incorrect in OpenZeppelin AST impl which served as a reference for our implementation https://github.com/OpenZeppelin/solidity-ast/pull/43