### PR TITLE
feat: allow passing extra cli args to solc + some cleanup

### DIFF
--- a/crates/artifacts/vyper/Cargo.toml
+++ b/crates/artifacts/vyper/Cargo.toml
@@ -21,6 +21,7 @@ foundry-compilers-core.workspace = true
 serde.workspace = true
 alloy-primitives.workspace = true
 alloy-json-abi.workspace = true
+semver.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 path-slash.workspace = true

--- a/crates/artifacts/vyper/src/input.rs
+++ b/crates/artifacts/vyper/src/input.rs
@@ -1,6 +1,7 @@
 use super::VyperSettings;
 use foundry_compilers_artifacts_solc::sources::Sources;
 use foundry_compilers_core::utils::strip_prefix_owned;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -46,5 +47,17 @@ impl VyperInput {
             .collect();
 
         self.settings.strip_prefix(base)
+    }
+
+    /// This will remove/adjust values in the [`VyperInput`] that are not compatible with this
+    /// version
+    pub fn sanitize(&mut self, version: &Version) {
+        self.settings.sanitize(version);
+    }
+
+    /// Consumes the type and returns a [VyperInput::sanitized] version
+    pub fn sanitized(mut self, version: &Version) -> Self {
+        self.sanitize(version);
+        self
     }
 }

--- a/crates/artifacts/vyper/src/settings.rs
+++ b/crates/artifacts/vyper/src/settings.rs
@@ -1,11 +1,14 @@
 use foundry_compilers_artifacts_solc::{
     output_selection::OutputSelection, serde_helpers, EvmVersion,
 };
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeSet,
     path::{Path, PathBuf},
 };
+
+pub const VYPER_SEARCH_PATHS: Version = Version::new(0, 4, 0);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -67,5 +70,20 @@ impl VyperSettings {
                 }
             })
         });
+    }
+
+    /// Sanitize the settings based on the compiler version.
+    pub fn sanitize(&mut self, version: &Version) {
+        if version < &VYPER_SEARCH_PATHS {
+            self.search_paths = None;
+        }
+
+        self.sanitize_output_selection();
+    }
+
+    /// Sanitize the settings based on the compiler version.
+    pub fn sanitized(mut self, version: &Version) -> Self {
+        self.sanitize(version);
+        self
     }
 }

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -103,10 +103,10 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// # Examples
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
+    /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let mut cache = CompilerCache::<Settings>::read(project.cache_path())?;
+    /// let mut cache = CompilerCache::<SolcSettings>::read(project.cache_path())?;
     /// cache.join_artifacts_files(project.artifacts_path());
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -129,10 +129,10 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// # Examples
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
+    /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
+    /// let cache: CompilerCache<SolcSettings> = CompilerCache::read_joined(&project.paths)?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn read_joined<L>(paths: &ProjectPathsConfig<L>) -> Result<Self> {
@@ -210,13 +210,11 @@ impl<S: CompilerSettings> CompilerCache<S> {
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
-    ///     artifacts::{contract::CompactContract, Settings},
-    ///     cache::CompilerCache,
-    ///     Project,
+    ///     artifacts::contract::CompactContract, cache::CompilerCache, solc::SolcSettings, Project,
     /// };
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let cache: CompilerCache<Settings> =
+    /// let cache: CompilerCache<SolcSettings> =
     ///     CompilerCache::read(project.cache_path())?.with_stripped_file_prefixes(project.root());
     /// let artifact: CompactContract = cache.read_artifact("src/Greeter.sol".as_ref(), "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -237,10 +235,10 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// # Examples
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
-    /// use foundry_compilers::{artifacts::Settings, cache::CompilerCache, Project};
+    /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
+    /// let cache: CompilerCache<SolcSettings> = CompilerCache::read_joined(&project.paths)?;
     /// cache.find_artifact_path("/Users/git/myproject/src/Greeter.sol".as_ref(), "Greeter");
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
@@ -256,13 +254,11 @@ impl<S: CompilerSettings> CompilerCache<S> {
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
-    ///     artifacts::{contract::CompactContract, Settings},
-    ///     cache::CompilerCache,
-    ///     Project,
+    ///     artifacts::contract::CompactContract, cache::CompilerCache, solc::SolcSettings, Project,
     /// };
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let cache = CompilerCache::<Settings>::read_joined(&project.paths)?;
+    /// let cache = CompilerCache::<SolcSettings>::read_joined(&project.paths)?;
     /// let artifact: CompactContract =
     ///     cache.read_artifact("/Users/git/myproject/src/Greeter.sol".as_ref(), "Greeter")?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -288,13 +284,12 @@ impl<S: CompilerSettings> CompilerCache<S> {
     #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
-    ///     artifacts::{contract::CompactContractBytecode, Settings},
-    ///     cache::CompilerCache,
+    ///     artifacts::contract::CompactContractBytecode, cache::CompilerCache, solc::SolcSettings,
     ///     Project,
     /// };
     ///
     /// let project = Project::builder().build(Default::default())?;
-    /// let cache: CompilerCache<Settings> = CompilerCache::read_joined(&project.paths)?;
+    /// let cache: CompilerCache<SolcSettings> = CompilerCache::read_joined(&project.paths)?;
     /// let artifacts = cache.read_artifacts::<CompactContractBytecode>()?;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -109,7 +109,7 @@ use crate::{
     output::{AggregatedCompilerOutput, Builds},
     report,
     resolver::GraphEdges,
-    ArtifactOutput, Graph, Project, ProjectCompileOutput, Sources,
+    ArtifactOutput, CompilerSettings, Graph, Project, ProjectCompileOutput, Sources,
 };
 use foundry_compilers_core::error::Result;
 use rayon::prelude::*;
@@ -447,11 +447,13 @@ impl<L: Language> CompilerSources<L> {
 
                 trace!("calling {} with {} sources {:?}", version, sources.len(), sources.keys());
 
-                let mut input = C::Input::build(sources, opt_settings, language, version.clone())
-                    .with_base_path(project.paths.root.clone())
-                    .with_allow_paths(project.paths.allowed_paths.clone())
-                    .with_include_paths(include_paths.clone())
-                    .with_remappings(project.paths.remappings.clone());
+                let settings = opt_settings
+                    .with_base_path(&project.paths.root)
+                    .with_allow_paths(&project.paths.allowed_paths)
+                    .with_include_paths(&include_paths)
+                    .with_remappings(&project.paths.remappings);
+
+                let mut input = C::Input::build(sources, settings, language, version.clone());
 
                 input.strip_prefix(project.paths.root.as_path());
 

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -74,6 +74,29 @@ pub trait CompilerSettings:
     /// Ensures that all settings fields are equal except for `output_selection` which is required
     /// to be a subset of `cached.output_selection`.
     fn can_use_cached(&self, other: &Self) -> bool;
+
+    /// Method which might be invoked to add remappings to the input.
+    fn with_remappings(self, _remappings: &[Remapping]) -> Self {
+        self
+    }
+
+    /// Builder method to set the base path for the compiler. Primarily used by solc implementation
+    /// to se --base-path.
+    fn with_base_path(self, _base_path: &Path) -> Self {
+        self
+    }
+
+    /// Builder method to set the allowed paths for the compiler. Primarily used by solc
+    /// implementation to set --allow-paths.
+    fn with_allow_paths(self, _allowed_paths: &BTreeSet<PathBuf>) -> Self {
+        self
+    }
+
+    /// Builder method to set the include paths for the compiler. Primarily used by solc
+    /// implementation to set --include-paths.
+    fn with_include_paths(self, _include_paths: &BTreeSet<PathBuf>) -> Self {
+        self
+    }
 }
 
 /// Input of a compiler, including sources and settings used for their compilation.
@@ -100,29 +123,6 @@ pub trait CompilerInput: Serialize + Send + Sync + Sized + Debug {
 
     /// Returns compiler name used by reporters to display output during compilation.
     fn compiler_name(&self) -> Cow<'static, str>;
-
-    /// Method which might be invoked to add remappings to the input.
-    fn with_remappings(self, _remappings: Vec<Remapping>) -> Self {
-        self
-    }
-
-    /// Builder method to set the base path for the compiler. Primarily used by solc implementation
-    /// to se --base-path.
-    fn with_base_path(self, _base_path: PathBuf) -> Self {
-        self
-    }
-
-    /// Builder method to set the allowed paths for the compiler. Primarily used by solc
-    /// implementation to set --allow-paths.
-    fn with_allow_paths(self, _allowed_paths: BTreeSet<PathBuf>) -> Self {
-        self
-    }
-
-    /// Builder method to set the include paths for the compiler. Primarily used by solc
-    /// implementation to set --include-paths.
-    fn with_include_paths(self, _include_paths: BTreeSet<PathBuf>) -> Self {
-        self
-    }
 
     /// Strips given prefix from all paths.
     fn strip_prefix(&mut self, base: &Path);

--- a/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/src/compilers/solc/compiler.rs
@@ -80,6 +80,8 @@ pub struct Solc {
     pub allow_paths: BTreeSet<PathBuf>,
     /// Value for --include-paths arg.
     pub include_paths: BTreeSet<PathBuf>,
+    /// Additional arbitrary arguments.
+    pub extra_args: Vec<String>,
 }
 
 impl Solc {
@@ -100,6 +102,7 @@ impl Solc {
             base_path: None,
             allow_paths: Default::default(),
             include_paths: Default::default(),
+            extra_args: Default::default(),
         }
     }
 
@@ -475,6 +478,7 @@ impl Solc {
             cmd.current_dir(base_path);
         }
 
+        cmd.args(&self.extra_args);
         cmd.arg("--standard-json");
 
         cmd

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -109,7 +109,7 @@ pub struct SolcVersionedInput {
     #[serde(flatten)]
     pub input: SolcInput,
     #[serde(flatten)]
-    cli_settings: CLISettings,
+    cli_settings: CliSettings,
 }
 
 impl CompilerInput for SolcVersionedInput {
@@ -155,7 +155,7 @@ impl CompilerInput for SolcVersionedInput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub struct CLISettings {
+pub struct CliSettings {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_args: Vec<String>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
@@ -173,7 +173,7 @@ pub struct SolcSettings {
     pub settings: Settings,
     /// Additional CLI args configuration
     #[serde(flatten)]
-    pub cli_settings: CLISettings,
+    pub cli_settings: CliSettings,
 }
 
 impl Deref for SolcSettings {

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -55,6 +55,7 @@ impl Compiler for SolcCompiler {
         solc.base_path.clone_from(&input.cli_settings.base_path);
         solc.allow_paths.clone_from(&input.cli_settings.allow_paths);
         solc.include_paths.clone_from(&input.cli_settings.include_paths);
+        solc.extra_args.clone_from(&input.cli_settings.extra_args);
 
         let solc_output = solc.compile(&input.input)?;
 

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -232,7 +232,7 @@ impl CompilerSettings for SolcSettings {
     }
 
     fn with_allow_paths(mut self, allowed_paths: &BTreeSet<PathBuf>) -> Self {
-        self.cli_settings.allow_paths = allowed_paths.clone();
+        self.cli_settings.allow_paths.clone_from(allowed_paths);
         self
     }
 
@@ -242,7 +242,7 @@ impl CompilerSettings for SolcSettings {
     }
 
     fn with_include_paths(mut self, include_paths: &BTreeSet<PathBuf>) -> Self {
-        self.cli_settings.include_paths = include_paths.clone();
+        self.cli_settings.include_paths.clone_from(include_paths);
         self
     }
 }

--- a/crates/compilers/src/compilers/vyper/input.rs
+++ b/crates/compilers/src/compilers/vyper/input.rs
@@ -8,8 +8,6 @@ use semver::Version;
 use serde::Serialize;
 use std::{borrow::Cow, path::Path};
 
-pub const VYPER_SEARCH_PATHS: Version = Version::new(0, 4, 0);
-
 #[derive(Clone, Debug, Serialize)]
 pub struct VyperVersionedInput {
     #[serde(flatten)]

--- a/crates/compilers/src/compilers/vyper/input.rs
+++ b/crates/compilers/src/compilers/vyper/input.rs
@@ -6,11 +6,7 @@ use crate::{
 use foundry_compilers_artifacts::sources::{Source, Sources};
 use semver::Version;
 use serde::Serialize;
-use std::{
-    borrow::Cow,
-    collections::BTreeSet,
-    path::{Path, PathBuf},
-};
+use std::{borrow::Cow, path::Path};
 
 pub const VYPER_SEARCH_PATHS: Version = Version::new(0, 4, 0);
 
@@ -57,12 +53,5 @@ impl CompilerInput for VyperVersionedInput {
             .iter()
             .chain(self.input.interfaces.iter())
             .map(|(path, source)| (path.as_path(), source))
-    }
-
-    fn with_include_paths(mut self, include_paths: BTreeSet<PathBuf>) -> Self {
-        if self.version >= VYPER_SEARCH_PATHS {
-            self.input.settings.search_paths = Some(include_paths);
-        }
-        self
     }
 }

--- a/crates/compilers/src/compilers/vyper/settings.rs
+++ b/crates/compilers/src/compilers/vyper/settings.rs
@@ -1,3 +1,5 @@
+use std::{collections::BTreeSet, path::PathBuf};
+
 pub use crate::artifacts::vyper::VyperSettings;
 use crate::compilers::CompilerSettings;
 use foundry_compilers_artifacts::output_selection::OutputSelection;
@@ -15,5 +17,10 @@ impl CompilerSettings for VyperSettings {
             && bytecode_metadata == &other.bytecode_metadata
             && output_selection.is_subset_of(&other.output_selection)
             && search_paths == &other.search_paths
+    }
+
+    fn with_include_paths(mut self, include_paths: &BTreeSet<PathBuf>) -> Self {
+        self.search_paths = Some(include_paths.clone());
+        self
     }
 }

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -52,13 +52,14 @@ use derivative::Derivative;
 use foundry_compilers_artifacts::solc::{
     output_selection::OutputSelection,
     sources::{Source, SourceCompilationKind, Sources},
-    Contract, Settings, Severity, SourceFile, StandardJsonCompilerInput,
+    Contract, Severity, SourceFile, StandardJsonCompilerInput,
 };
 use foundry_compilers_core::error::{Result, SolcError, SolcIoError};
 use output::sources::{VersionedSourceFile, VersionedSourceFiles};
 use project::ProjectCompiler;
 use semver::Version;
 use solang_parser::pt::SourceUnitPart;
+use solc::SolcSettings;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fs,
@@ -148,7 +149,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
 
 impl<C: Compiler, T: ArtifactOutput> Project<C, T>
 where
-    C::Settings: Into<Settings>,
+    C::Settings: Into<SolcSettings>,
 {
     /// Returns standard-json-input to compile the target contract
     pub fn standard_json_input(&self, target: &Path) -> Result<StandardJsonCompilerInput> {
@@ -186,7 +187,7 @@ where
             .map(|r| r.into_relative(self.root()).to_relative_remapping())
             .collect::<Vec<_>>();
 
-        let input = StandardJsonCompilerInput::new(sources, settings);
+        let input = StandardJsonCompilerInput::new(sources, settings.settings);
 
         Ok(input)
     }

--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         Compiler,
     },
     config::ProjectPathsConfigBuilder,
+    solc::SolcSettings,
     Artifact, ArtifactOutput, Artifacts, ConfigurableArtifacts, HardhatArtifacts, PathStyle,
     Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig,
 };
@@ -47,7 +48,7 @@ impl<T: ArtifactOutput + Default> TempProject<MultiCompiler, T> {
 
     /// Overwrites the settings to pass to `solc`
     pub fn with_solc_settings(mut self, settings: impl Into<Settings>) -> Self {
-        self.inner.settings.solc = settings.into();
+        self.inner.settings.solc = SolcSettings { settings: settings.into(), ..Default::default() };
         self
     }
 


### PR DESCRIPTION
This refactors `Compiler` a bit moving some of the configuration methods from `CompilerInput` to `CompilerSettings`, preferring sanitization of settings during input construction instead of in `with_*` methods of version-aware input.

Instead of using JSON solc settings, I've added separate `SolcSettings` type divided into JSON and CLI settings