### PR TITLE
feat: add `eofVersion` config option

### DIFF
--- a/crates/artifacts/solc/Cargo.toml
+++ b/crates/artifacts/solc/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { workspace = true, optional = true }
 tracing.workspace = true
 walkdir.workspace = true
 yansi.workspace = true
+serde_repr = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 path-slash.workspace = true

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -271,6 +271,7 @@ pub struct Settings {
     /// If this key is an empty string, that refers to a global level.
     #[serde(default)]
     pub libraries: Libraries,
+    /// Specify EOF version to produce.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub eof_version: Option<u8>,
 }

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -271,6 +271,8 @@ pub struct Settings {
     /// If this key is an empty string, that refers to a global level.
     #[serde(default)]
     pub libraries: Libraries,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eof_version: Option<u8>,
 }
 
 impl Settings {
@@ -546,6 +548,7 @@ impl Default for Settings {
             libraries: Default::default(),
             remappings: Default::default(),
             model_checker: None,
+            eof_version: None,
         }
         .with_ast()
     }

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -9,6 +9,7 @@ extern crate tracing;
 
 use semver::Version;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashSet},
@@ -273,7 +274,14 @@ pub struct Settings {
     pub libraries: Libraries,
     /// Specify EOF version to produce.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub eof_version: Option<u8>,
+    pub eof_version: Option<EofVersion>,
+}
+
+/// Available EOF versions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum EofVersion {
+    V1 = 1,
 }
 
 impl Settings {

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -209,6 +209,7 @@ impl CompilerSettings for SolcSettings {
                     via_ir,
                     debug,
                     libraries,
+                    eof_version,
                 },
             ..
         } = self;
@@ -222,6 +223,7 @@ impl CompilerSettings for SolcSettings {
             && *via_ir == other.settings.via_ir
             && *debug == other.settings.debug
             && *libraries == other.settings.libraries
+            && *eof_version == other.settings.eof_version
             && output_selection.is_subset_of(&other.settings.output_selection)
     }
 


### PR DESCRIPTION
adds key for enabling eof which is supported by https://github.com/ipsilon/solidity/tree/eof-functions-rebased

solc allows unknown keys in settings, so setting this wouldn't break default solc. though I think it might make sense to be under a feature flag. wdyt @mattsse 