### PR TITLE
feat: more user-friendly error when no compiler is available

### DIFF
--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -633,6 +633,13 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
                 compiler.available_versions(&language)
             };
 
+            if all_versions.is_empty() && !nodes.is_empty() {
+                return Err(SolcError::msg(format!(
+                    "Found {} sources, but no compiler versions are available for it",
+                    language
+                )));
+            }
+
             // stores all versions and their nodes that can be compiled
             let mut versioned_nodes = HashMap::new();
 
@@ -656,7 +663,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
                     } else {
                         let mut msg = String::new();
                         self.format_imports_list(idx, &mut msg).unwrap();
-                        errors.push(format!("Found incompatible Solidity versions:\n{msg}"));
+                        errors.push(format!("Found incompatible versions:\n{msg}"));
                     }
 
                     erroneous_nodes.insert(idx);

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -635,8 +635,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
 
             if all_versions.is_empty() && !nodes.is_empty() {
                 return Err(SolcError::msg(format!(
-                    "Found {} sources, but no compiler versions are available for it",
-                    language
+                    "Found {language} sources, but no compiler versions are available for it"
                 )));
             }
 


### PR DESCRIPTION
Currently, if no Vyper or Solidity compiler is available, returned error would look like:
```
Found incompatible Solidity versions:
src/a.vy  imports:
    src/b.vy 
Found incompatible Solidity versions:
src/b.vy  imports:
...
```

This PR adds logic for catching case when the error is caused by missing compiler for the language