### PR TITLE
feat: always provide `Default` for `MultiCompiler`

### DIFF
--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -101,7 +101,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// If the cache file does not exist
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
@@ -127,7 +126,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     ///
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
@@ -228,7 +226,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// `src/Greeter.sol` if `base` is `/Users/me/project`
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
     ///     artifacts::contract::CompactContract, cache::CompilerCache, solc::SolcSettings, Project,
@@ -254,7 +251,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// Returns the path to the artifact of the given `(file, contract)` pair
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{cache::CompilerCache, solc::SolcSettings, Project};
     ///
@@ -272,7 +268,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// [`Self::find_artifact_path()`]) and deserializes the artifact file as JSON.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
     ///     artifacts::contract::CompactContract, cache::CompilerCache, solc::SolcSettings, Project,
@@ -302,7 +297,6 @@ impl<S: CompilerSettings> CompilerCache<S> {
     /// Reads all cached artifacts from disk using the given ArtifactOutput handler
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
     ///     artifacts::contract::CompactContractBytecode, cache::CompilerCache, solc::SolcSettings,

--- a/crates/compilers/src/compile/output/contracts.rs
+++ b/crates/compilers/src/compile/output/contracts.rs
@@ -43,7 +43,6 @@ impl VersionedContracts {
     /// Finds the _first_ contract with the given name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -61,7 +60,6 @@ impl VersionedContracts {
     /// Finds the contract with matching path and name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -84,7 +82,6 @@ impl VersionedContracts {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -111,7 +108,6 @@ impl VersionedContracts {
     ///  Removes the contract with matching path and name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -112,7 +112,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// This returns a chained iterator of both cached and recompiled contract artifacts
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, ArtifactId, Project};
     /// use std::collections::btree_map::BTreeMap;
@@ -131,7 +130,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// the contract name and the corresponding artifact
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
     /// use std::collections::btree_map::BTreeMap;
@@ -149,7 +147,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// the contract name and the corresponding artifact with its version
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
     /// use semver::Version;
@@ -192,7 +189,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// This returns a chained iterator of both cached and recompiled contract artifacts
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::ConfigurableContractArtifact, Project};
     /// use std::{collections::btree_map::BTreeMap, path::PathBuf};
@@ -237,7 +233,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// # Examples
     ///
     /// Make all artifact files relative to the project's root directory
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -254,7 +249,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Returns a reference to the (merged) solc compiler output.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::contract::Contract, Project};
     /// use std::collections::btree_map::BTreeMap;
@@ -329,7 +323,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// [`Self::remove_first`].
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
@@ -351,7 +344,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Finds the artifact with matching path and name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -378,7 +370,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Finds the artifact with matching path and name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -397,7 +388,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -421,7 +411,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     ///
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
@@ -447,7 +436,6 @@ impl<T: ArtifactOutput, C: Compiler> ProjectCompileOutput<C, T> {
     /// [`foundry_compilers_artifacts::ConfigurableContractArtifact`]
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{
     ///     artifacts::contract::CompactContractBytecode, contracts::ArtifactContracts, ArtifactId,
@@ -631,7 +619,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Finds the _first_ contract with the given name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -647,7 +634,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Removes the _first_ contract with the given name from the set
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -663,7 +649,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// Removes the contract with matching path and name
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -683,7 +668,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// [Self::remove_first]
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, info::ContractInfo, Project};
     ///
@@ -747,7 +731,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// bytecode, runtime bytecode, and ABI.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -764,7 +747,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// provide several helper methods
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -792,7 +774,6 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
     /// # Examples
     ///
     /// Make all sources and contracts relative to the project's root directory
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///

--- a/crates/compilers/src/compile/output/sources.rs
+++ b/crates/compilers/src/compile/output/sources.rs
@@ -56,7 +56,6 @@ impl VersionedSourceFiles {
     /// Finds the _first_ source file with the given path.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -85,7 +84,6 @@ impl VersionedSourceFiles {
     /// Finds the _first_ source file with the given id
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -109,7 +107,6 @@ impl VersionedSourceFiles {
     /// Removes the _first_ source_file with the given path from the set
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///
@@ -131,7 +128,6 @@ impl VersionedSourceFiles {
     /// Removes the _first_ source_file with the given id from the set
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{artifacts::*, Project};
     ///

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -171,7 +171,6 @@ impl<'a, T: ArtifactOutput, C: Compiler> ProjectCompiler<'a, T, C> {
     /// `Contract`s
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -110,7 +110,6 @@ impl Project {
     /// # Examples
     ///
     /// Configure with [ConfigurableArtifacts] artifacts output and [MultiCompiler] compiler:
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -119,7 +118,6 @@ impl Project {
     /// ```
     ///
     /// To configure any a project with any `ArtifactOutput` use either:
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -128,7 +126,6 @@ impl Project {
     /// ```
     ///
     /// or use the builder directly:
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{multi::MultiCompiler, ConfigurableArtifacts, ProjectBuilder};
     ///
@@ -249,7 +246,6 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Use this if you compile a project in a `build.rs` file.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::{Project, ProjectPathsConfig};
     ///
@@ -274,7 +270,6 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Convenience function to compile a single solidity file with the project's settings.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -292,7 +287,6 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// Same as [`Self::compile()`] but with the given `files` as input.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```no_run
     /// use foundry_compilers::Project;
     ///
@@ -315,7 +309,6 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
     /// If the cache file was the only file in the folder, this also removes the empty folder.
     ///
     /// # Examples
-    #[cfg_attr(not(feature = "svm-solc"), doc = "```ignore")]
     /// ```
     /// use foundry_compilers::Project;
     ///

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -3973,7 +3973,8 @@ fn test_can_compile_multi() {
         solc: Default::default(),
     };
 
-    let compiler = MultiCompiler { solc: SolcCompiler::default(), vyper: Some(VYPER.clone()) };
+    let compiler =
+        MultiCompiler { solc: Some(SolcCompiler::default()), vyper: Some(VYPER.clone()) };
 
     let project = ProjectBuilder::<MultiCompiler>::new(Default::default())
         .settings(settings)


### PR DESCRIPTION
Closes https://github.com/foundry-rs/compilers/issues/187
Closes https://github.com/foundry-rs/compilers/issues/168

Updates `MultiCompiler` and makes solc compiler on it optional. If `svm-solc` is not activated, it is attempted to initialize solc via `Solc::new("solc")`, and if solc binary is not available in command line, it is set to None.

We could also add `svm-solc` to default features as I think people would often prefer enabling it as it's required to emulate foundry's default behavior.