### PR TITLE
chore: fix up the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ Example usage:
 
 ```rust,ignore
 use foundry_compilers::{Project, ProjectPathsConfig};
+use std::path::Path;
 
 // configure the project with all its paths, solc, cache etc.
 let project = Project::builder()
-    .paths(ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR")).unwrap())
+    .paths(ProjectPathsConfig::hardhat(&Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap())
     .build(Default::default())
     .unwrap();
 let output = project.compile().unwrap();

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ use std::path::Path;
 
 // configure the project with all its paths, solc, cache etc.
 let project = Project::builder()
-    .paths(ProjectPathsConfig::hardhat(&Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap())
+    .paths(ProjectPathsConfig::hardhat(Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap())
     .build(Default::default())
     .unwrap();
 let output = project.compile().unwrap();


### PR DESCRIPTION
Due to the this commit:

commit bc96471cf13d1d1030e3773b29609d4fd3621579
Author: DaniPopes <57450786+DaniPopes@users.noreply.github.com>
Date:   Sat Jun 29 00:20:26 2024 +0200

    chore: remove most impl AsRef<str,Path> (#157)

The interface for `hardhat()` is updated to `&Path`.