### PR TITLE
[wip] preprocessor PoC

### DIFF
--- a/crates/artifacts/solc/src/ast/misc.rs
+++ b/crates/artifacts/solc/src/ast/misc.rs
@@ -4,7 +4,7 @@ use std::{fmt, fmt::Write, str::FromStr};
 /// Represents the source location of a node: `<start byte>:<length>:<source index>`.
 ///
 /// The `start`, `length` and `index` can be -1 which is represented as `None`
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SourceLocation {
     pub start: Option<usize>,
     pub length: Option<usize>,

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -786,14 +786,6 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
             sources.insert(file.clone(), source);
         }
 
-        let src_files = sources
-            .keys()
-            .filter(|f| {
-                !f.starts_with(&self.project.paths.tests)
-                    && !f.starts_with(&self.project.paths.scripts)
-            })
-            .collect::<HashSet<_>>();
-
         // Calculate content hashes for later comparison.
         self.fill_hashes(&sources);
 
@@ -803,6 +795,14 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
                 self.dirty_sources.insert(file.clone());
             }
         }
+
+        let src_files = sources
+            .keys()
+            .filter(|f| {
+                !f.starts_with(&self.project.paths.tests)
+                    && !f.starts_with(&self.project.paths.scripts)
+            })
+            .collect::<HashSet<_>>();
 
         // Mark sources as dirty based on their imports
         for (file, entry) in &self.cache.files {

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -658,7 +658,7 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
         let content_hash = source.content_hash();
         let interface_repr_hash = file
             .starts_with(&self.project.paths.sources)
-            .then(|| interface_representation_hash(&source));
+            .then(|| interface_representation_hash(source));
         let entry = CacheEntry {
             last_modification_date: CacheEntry::<C::Settings>::read_last_modification_date(&file)
                 .unwrap_or_default(),
@@ -788,7 +788,10 @@ impl<'a, T: ArtifactOutput, C: Compiler> ArtifactsCacheInner<'a, T, C> {
 
         let src_files = sources
             .keys()
-            .filter(|f| f.starts_with(&self.project.paths.sources))
+            .filter(|f| {
+                !f.starts_with(&self.project.paths.tests)
+                    && !f.starts_with(&self.project.paths.scripts)
+            })
             .collect::<HashSet<_>>();
 
         // Calculate content hashes for later comparison.

--- a/crates/compilers/src/cache.rs
+++ b/crates/compilers/src/cache.rs
@@ -4,7 +4,7 @@ use crate::{
     buildinfo::RawBuildInfo,
     compilers::{Compiler, CompilerSettings, Language},
     output::Builds,
-    preprocessor::{interface_representation_hash},
+    preprocessor::interface_representation_hash,
     resolver::GraphEdges,
     ArtifactFile, ArtifactOutput, Artifacts, ArtifactsMap, Graph, OutputContext, Project,
     ProjectPaths, ProjectPathsConfig, SourceCompilationKind,

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -476,14 +476,6 @@ impl<L: Language> CompilerSources<L> {
                 let mut input = C::Input::build(sources, settings, language, version.clone());
 
                 input.strip_prefix(project.paths.root.as_path());
-                let actually_dirty = actually_dirty
-                    .into_iter()
-                    .map(|path| {
-                        path.strip_prefix(project.paths.root.as_path())
-                            .unwrap_or(&path)
-                            .to_path_buf()
-                    })
-                    .collect();
 
                 if let Some(preprocessor) = preprocessor.as_ref() {
                     input = preprocessor.preprocess(&project.compiler, input, &project.paths)?;
@@ -511,7 +503,11 @@ impl<L: Language> CompilerSources<L> {
 
             let build_info = RawBuildInfo::new(&input, &output, project.build_info)?;
 
-            output.retain_files(actually_dirty);
+            output.retain_files(
+                actually_dirty
+                    .iter()
+                    .map(|f| f.strip_prefix(project.paths.root.as_path()).unwrap_or(f)),
+            );
             output.join_all(project.paths.root.as_path());
 
             aggregated.extend(version.clone(), build_info, output);

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -24,7 +24,7 @@ pub use resolver::Graph;
 pub mod compilers;
 pub use compilers::*;
 
-mod preprocessor;
+pub mod preprocessor;
 
 mod compile;
 pub use compile::{

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -24,6 +24,8 @@ pub use resolver::Graph;
 pub mod compilers;
 pub use compilers::*;
 
+mod preprocessor;
+
 mod compile;
 pub use compile::{
     output::{AggregatedCompilerOutput, ProjectCompileOutput},

--- a/crates/compilers/src/preprocessor.rs
+++ b/crates/compilers/src/preprocessor.rs
@@ -1,4 +1,7 @@
+use alloy_primitives::hex;
+use foundry_compilers_artifacts::Source;
 use foundry_compilers_core::utils;
+use md5::Digest;
 use solang_parser::{
     diagnostics::Diagnostic,
     helpers::CodeLocation,
@@ -55,6 +58,14 @@ pub(crate) fn interface_representation(content: &str) -> Result<String, Vec<Diag
 
     let content = content.replace("\n", "");
     Ok(utils::RE_TWO_OR_MORE_SPACES.replace_all(&content, "").to_string())
+}
+
+pub(crate) fn interface_representation_hash(source: &Source) -> String {
+    let Ok(repr) = interface_representation(&source.content) else { return source.content_hash() };
+    let mut hasher = md5::Md5::new();
+    hasher.update(&repr);
+    let result = hasher.finalize();
+    hex::encode(result)
 }
 
 #[cfg(test)]

--- a/crates/compilers/src/preprocessor.rs
+++ b/crates/compilers/src/preprocessor.rs
@@ -1,0 +1,90 @@
+use foundry_compilers_core::utils;
+use solang_parser::{
+    diagnostics::Diagnostic,
+    helpers::CodeLocation,
+    pt::{ContractPart, ContractTy, FunctionAttribute, FunctionTy, SourceUnitPart, Visibility},
+};
+
+pub(crate) fn interface_representation(content: &str) -> Result<String, Vec<Diagnostic>> {
+    let (source_unit, _) = solang_parser::parse(&content, 0)?;
+    let mut locs_to_remove = Vec::new();
+
+    for part in source_unit.0 {
+        if let SourceUnitPart::ContractDefinition(contract) = part {
+            if matches!(contract.ty, ContractTy::Interface(_) | ContractTy::Library(_)) {
+                continue;
+            }
+            for part in contract.parts {
+                if let ContractPart::FunctionDefinition(func) = part {
+                    let is_exposed = func.ty == FunctionTy::Function
+                        && func.attributes.iter().any(|attr| {
+                            matches!(
+                                attr,
+                                FunctionAttribute::Visibility(
+                                    Visibility::External(_) | Visibility::Public(_)
+                                )
+                            )
+                        })
+                        || matches!(
+                            func.ty,
+                            FunctionTy::Constructor | FunctionTy::Fallback | FunctionTy::Receive
+                        );
+
+                    if !is_exposed {
+                        locs_to_remove.push(func.loc);
+                    }
+
+                    if let Some(ref body) = func.body {
+                        locs_to_remove.push(body.loc());
+                    }
+                }
+            }
+        }
+    }
+
+    let mut content = content.to_string();
+    let mut offset = 0;
+
+    for loc in locs_to_remove {
+        let start = loc.start() - offset;
+        let end = loc.end() - offset;
+
+        content.replace_range(start..end, "");
+        offset += end - start;
+    }
+
+    let content = content.replace("\n", "");
+    Ok(utils::RE_TWO_OR_MORE_SPACES.replace_all(&content, "").to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interface_representation() {
+        let content = r#"
+library Lib {
+    function libFn() internal {
+        // logic to keep
+    }
+}
+contract A {
+    function a() external {}
+    function b() public {}
+    function c() internal {
+        // logic logic logic
+    }
+    function d() private {}
+    function e() external {
+        // logic logic logic
+    }
+}"#;
+
+        let result = interface_representation(content).unwrap();
+        assert_eq!(
+            result,
+            r#"library Lib {function libFn() internal {// logic to keep}}contract A {function a() externalfunction b() publicfunction e() external }"#
+        );
+    }
+}

--- a/crates/compilers/src/preprocessor.rs
+++ b/crates/compilers/src/preprocessor.rs
@@ -1,11 +1,28 @@
+use super::project::Preprocessor;
+use crate::{
+    flatten::{apply_updates, Updates},
+    multi::{MultiCompiler, MultiCompilerInput},
+    solc::{SolcCompiler, SolcVersionedInput},
+    Compiler, Result, SolcError,
+};
 use alloy_primitives::hex;
-use foundry_compilers_artifacts::Source;
+use foundry_compilers_artifacts::{
+    ast::SourceLocation,
+    output_selection::OutputSelection,
+    visitor::{Visitor, Walk},
+    ContractDefinition, ContractKind, Expression, FunctionCall, MemberAccess, NewExpression,
+    Source, SourceUnit, SourceUnitPart, Sources, TypeName,
+};
 use foundry_compilers_core::utils;
-use md5::Digest;
+use md5::{digest::typenum::Exp, Digest};
 use solang_parser::{
     diagnostics::Diagnostic,
     helpers::CodeLocation,
     pt::{ContractPart, ContractTy, FunctionAttribute, FunctionTy, SourceUnitPart, Visibility},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
 };
 
 pub(crate) fn interface_representation(content: &str) -> Result<String, Vec<Diagnostic>> {
@@ -66,6 +83,274 @@ pub(crate) fn interface_representation_hash(source: &Source) -> String {
     hasher.update(&repr);
     let result = hasher.finalize();
     hex::encode(result)
+}
+
+#[derive(Debug)]
+pub struct ItemLocation {
+    start: usize,
+    end: usize,
+}
+
+impl ItemLocation {
+    fn try_from_loc(loc: SourceLocation) -> Option<ItemLocation> {
+        Some(ItemLocation { start: loc.start?, end: loc.start? + loc.length? })
+    }
+}
+
+#[derive(Debug)]
+enum BytecodeDependencyKind {
+    CreationCode,
+    New(ItemLocation, String),
+}
+
+#[derive(Debug)]
+struct BytecodeDependency {
+    kind: BytecodeDependencyKind,
+    loc: ItemLocation,
+    referenced_contract: usize,
+}
+
+#[derive(Debug)]
+struct BytecodeDependencyCollector<'a> {
+    source: &'a str,
+    dependencies: Vec<BytecodeDependency>,
+}
+
+impl BytecodeDependencyCollector<'_> {
+    fn new(source: &str) -> BytecodeDependencyCollector<'_> {
+        BytecodeDependencyCollector { source, dependencies: Vec::new() }
+    }
+}
+
+impl Visitor for BytecodeDependencyCollector<'_> {
+    fn visit_function_call(&mut self, call: &FunctionCall) {
+        let (new_loc, expr) = match &call.expression {
+            Expression::NewExpression(expr) => (expr.src, expr),
+            Expression::FunctionCallOptions(expr) => {
+                if let Expression::NewExpression(new_expr) = &expr.expression {
+                    (expr.src, new_expr)
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+
+        let TypeName::UserDefinedTypeName(type_name) = &expr.type_name else { return };
+
+        let Some(loc) = ItemLocation::try_from_loc(call.src) else { return };
+        let Some(name_loc) = ItemLocation::try_from_loc(type_name.src) else { return };
+        let Some(new_loc) = ItemLocation::try_from_loc(new_loc) else { return };
+        let name = &self.source[name_loc.start..name_loc.end];
+
+        self.dependencies.push(BytecodeDependency {
+            kind: BytecodeDependencyKind::New(new_loc, name.to_string()),
+            loc,
+            referenced_contract: type_name.referenced_declaration as usize,
+        });
+    }
+
+    fn visit_member_access(&mut self, access: &MemberAccess) {
+        if access.member_name != "creationCode" {
+            return;
+        }
+
+        let Expression::FunctionCall(call) = &access.expression else { return };
+
+        let Expression::Identifier(ident) = &call.expression else { return };
+
+        if ident.name != "type" {
+            return;
+        }
+
+        let Some(Expression::Identifier(ident)) = call.arguments.first() else { return };
+
+        let Some(referenced) = ident.referenced_declaration else { return };
+
+        let Some(loc) = ItemLocation::try_from_loc(access.src) else { return };
+
+        self.dependencies.push(BytecodeDependency {
+            kind: BytecodeDependencyKind::CreationCode,
+            loc,
+            referenced_contract: referenced as usize,
+        });
+    }
+}
+
+struct TestOptimizer<'a> {
+    asts: BTreeMap<PathBuf, SourceUnit>,
+    dirty: &'a Vec<PathBuf>,
+    sources: &'a mut Sources,
+}
+
+impl TestOptimizer<'_> {
+    fn new<'a>(
+        asts: BTreeMap<PathBuf, SourceUnit>,
+        dirty: &'a Vec<PathBuf>,
+        sources: &'a mut Sources,
+    ) -> TestOptimizer<'a> {
+        TestOptimizer { asts, dirty, sources }
+    }
+
+    fn optimize(self) {
+        let mut updates = Updates::default();
+        let ignored_contracts = self.collect_ignored_contracts();
+        self.rename_contracts_to_abstract(&ignored_contracts, &mut updates);
+        self.remove_bytecode_dependencies(&ignored_contracts, &mut updates);
+
+        apply_updates(self.sources, updates);
+    }
+
+    fn collect_ignored_contracts(&self) -> BTreeSet<usize> {
+        let mut ignored_sources = BTreeSet::new();
+
+        for (path, ast) in &self.asts {
+            if path.to_str().unwrap().contains("test") || path.to_str().unwrap().contains("script")
+            {
+                ignored_sources.insert(ast.id);
+            } else if self.dirty.contains(path) {
+                ignored_sources.insert(ast.id);
+
+                for node in &ast.nodes {
+                    if let SourceUnitPart::ImportDirective(import) = node {
+                        ignored_sources.insert(import.source_unit);
+                    }
+                }
+            }
+        }
+
+        let mut ignored_contracts = BTreeSet::new();
+
+        for ast in self.asts.values() {
+            if ignored_sources.contains(&ast.id) {
+                for node in &ast.nodes {
+                    if let SourceUnitPart::ContractDefinition(contract) = node {
+                        ignored_contracts.insert(contract.id);
+                    }
+                }
+            }
+        }
+
+        ignored_contracts
+    }
+
+    fn rename_contracts_to_abstract(
+        &self,
+        ignored_contracts: &BTreeSet<usize>,
+        updates: &mut Updates,
+    ) {
+        for (path, ast) in &self.asts {
+            for node in &ast.nodes {
+                if let SourceUnitPart::ContractDefinition(contract) = node {
+                    if ignored_contracts.contains(&contract.id) {
+                        continue;
+                    }
+                    if matches!(contract.kind, ContractKind::Contract) && !contract.is_abstract {
+                        if let Some(start) = contract.src.start {
+                            updates.entry(path.clone()).or_default().insert((
+                                start,
+                                start,
+                                "abstract ".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn remove_bytecode_dependencies(
+        &self,
+        ignored_contracts: &BTreeSet<usize>,
+        updates: &mut Updates,
+    ) {
+        for (path, ast) in &self.asts {
+            let src = self.sources.get(path).unwrap().content.as_str();
+            let mut collector = BytecodeDependencyCollector::new(src);
+            ast.walk(&mut collector);
+            let updates = updates.entry(path.clone()).or_default();
+            for dep in collector.dependencies {
+                match dep.kind {
+                    BytecodeDependencyKind::CreationCode => {
+                        updates.insert((dep.loc.start, dep.loc.end, "bytes(\"\")".to_string()));
+                    }
+                    BytecodeDependencyKind::New(new_loc, name) => {
+                        updates.insert((
+                            new_loc.start,
+                            new_loc.end,
+                            format!("{name}(payable(address(uint160(uint256(keccak256(abi.encode"),
+                        ));
+                        updates.insert((dep.loc.end, dep.loc.end, format!("))))))")));
+                    }
+                };
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TestOptimizerPreprocessor;
+
+impl Preprocessor<SolcCompiler> for TestOptimizerPreprocessor {
+    fn preprocess(
+        &self,
+        solc: &SolcCompiler,
+        mut input: SolcVersionedInput,
+        dirty: &Vec<PathBuf>,
+    ) -> Result<SolcVersionedInput> {
+        let prev_output_selection = std::mem::replace(
+            &mut input.input.settings.output_selection,
+            OutputSelection::ast_output_selection(),
+        );
+        let output = solc.compile(&input)?;
+
+        input.input.settings.output_selection = prev_output_selection;
+
+        if let Some(e) = output.errors.iter().find(|e| e.severity.is_error()) {
+            return Err(SolcError::msg(e));
+        }
+
+        let asts = output
+            .sources
+            .into_iter()
+            .filter_map(|(path, source)| {
+                if !input.input.sources.contains_key(&path) {
+                    return None;
+                }
+
+                Some((|| {
+                    let ast = source.ast.ok_or_else(|| SolcError::msg("missing AST"))?;
+                    let ast: SourceUnit = serde_json::from_str(&serde_json::to_string(&ast)?)?;
+                    Ok((path, ast))
+                })())
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+
+        TestOptimizer::new(asts, dirty, &mut input.input.sources).optimize();
+
+        Ok(input)
+    }
+}
+
+impl Preprocessor<MultiCompiler> for TestOptimizerPreprocessor {
+    fn preprocess(
+        &self,
+        compiler: &MultiCompiler,
+        input: <MultiCompiler as Compiler>::Input,
+        dirty: &Vec<PathBuf>,
+    ) -> Result<<MultiCompiler as Compiler>::Input> {
+        match input {
+            MultiCompilerInput::Solc(input) => {
+                if let Some(solc) = &compiler.solc {
+                    let input = self.preprocess(solc, input, dirty)?;
+                    Ok(MultiCompilerInput::Solc(input))
+                } else {
+                    Ok(MultiCompilerInput::Solc(input))
+                }
+            }
+            MultiCompilerInput::Vyper(input) => Ok(MultiCompilerInput::Vyper(input)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/compilers/src/preprocessor.rs
+++ b/crates/compilers/src/preprocessor.rs
@@ -5,7 +5,7 @@ use crate::{
     solc::{SolcCompiler, SolcVersionedInput},
     Compiler, ProjectPathsConfig, Result, SolcError,
 };
-use alloy_primitives::{hex};
+use alloy_primitives::hex;
 use foundry_compilers_artifacts::{
     ast::SourceLocation,
     output_selection::OutputSelection,
@@ -301,7 +301,6 @@ impl BytecodeDependencyOptimizer<'_> {
             }
             let mut collector = BytecodeDependencyCollector::new(src);
             ast.walk(&mut collector);
-
 
             // It is possible to write weird expressions which we won't catch.
             // e.g. (((new Contract)))() is valid syntax

--- a/crates/compilers/src/preprocessor.rs
+++ b/crates/compilers/src/preprocessor.rs
@@ -102,6 +102,7 @@ impl ItemLocation {
     }
 }
 
+/// Checks if the given path is a test/script file.
 fn is_test_or_script<L>(path: &Path, paths: &ProjectPathsConfig<L>) -> bool {
     let test_dir = paths.tests.strip_prefix(&paths.root).unwrap_or(&paths.root);
     let script_dir = paths.scripts.strip_prefix(&paths.root).unwrap_or(&paths.root);
@@ -318,14 +319,6 @@ impl BytecodeDependencyOptimizer<'_> {
         BytecodeDependencyOptimizer { asts, paths, sources }
     }
 
-    /// Returns true if the file is not a test or script file.
-    fn is_src_file(&self, file: &Path) -> bool {
-        let tests = self.paths.tests.strip_prefix(&self.paths.root).unwrap_or(&self.paths.root);
-        let scripts = self.paths.scripts.strip_prefix(&self.paths.root).unwrap_or(&self.paths.root);
-
-        !file.starts_with(tests) && !file.starts_with(scripts)
-    }
-
     fn process(self) -> Result<()> {
         let mut updates = Updates::default();
 
@@ -348,7 +341,7 @@ impl BytecodeDependencyOptimizer<'_> {
         for (path, ast) in &self.asts {
             let src = self.sources.get(path).unwrap().content.as_str();
 
-            if !self.is_src_file(path) {
+            if is_test_or_script(path, &self.paths) {
                 continue;
             }
 
@@ -412,7 +405,7 @@ impl BytecodeDependencyOptimizer<'_> {
         updates: &mut Updates,
     ) -> Result<()> {
         for (path, ast) in &self.asts {
-            if self.is_src_file(path) {
+            if !is_test_or_script(path, &self.paths) {
                 continue;
             }
             let src = self.sources.get(path).unwrap().content.as_str();

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -70,6 +70,9 @@ pub enum SolcError {
     #[error("no artifact found for `{}:{}`", .0.display(), .1)]
     ArtifactNotFound(PathBuf, String),
 
+    #[error(transparent)]
+    Fmt(#[from] std::fmt::Error),
+
     #[cfg(feature = "project-util")]
     #[error(transparent)]
     FsExtra(#[from] fs_extra::error::Error),

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, SolcError>;
+pub type Result<T, E = SolcError> = std::result::Result<T, E>;
 
 #[allow(unused_macros)]
 #[macro_export]

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -42,6 +42,9 @@ pub static RE_SOL_SDPX_LICENSE_IDENTIFIER: Lazy<Regex> =
 /// A regex used to remove extra lines in flatenned files
 pub static RE_THREE_OR_MORE_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new("\n{3,}").unwrap());
 
+/// A regex used to remove extra lines in flatenned files
+pub static RE_TWO_OR_MORE_SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(" {2,}").unwrap());
+
 /// A regex that matches version pragma in a Vyper
 pub static RE_VYPER_VERSION: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"#(?:pragma version|@version)\s+(?P<version>.+)").unwrap());


### PR DESCRIPTION
ref #197 

Implements preprocessor allowing us to skip recompiling tests on non-interface source file changes. Still testing, but looks like it's working correctly, decreasing single-change build times from ~1 minute to 5s in some cases.

Implementation needed some hacks to correctly handle constructor arguments, tried to document it clearly - https://github.com/foundry-rs/compilers/blob/15ce120c2e17aa384a43af79a202a36ac78a0c6f/crates/compilers/src/preprocessor.rs#L265

still WIP as caching changes are not opt-in yet (preprocessor is), and I want to do more testing