### PR TITLE
Fix: Ast Node Bindings

### DIFF
--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -257,7 +257,7 @@ pub enum AssignmentOperator {
     ShlAssign,
 }
 
-ast_node!(
+expr_node!(
     /// A binary operation.
     struct BinaryOperation {
         common_type: TypeDescriptions,
@@ -938,7 +938,7 @@ stmt_node!(
     /// A return statement.
     struct Return {
         expression: Option<Expression>,
-        function_return_parameters: usize,
+        function_return_parameters: Option<usize>,
     }
 );
 


### PR DESCRIPTION
Fix for 2 ast node bindings

* BinaryOperation can qualify as an `expr_node!`
* Return AST Node's `function_return_parameters` should be made optional because when return is used inside modifiers, the AST generated by solc doesn't include the `function_return_parameters` field

More context:
I tried using these changes on [Aderyn](https://github.com/Cyfrin/aderyn/blob/5c483fdbf1f454ca42c1fd9b85353b0b9241c43a/aderyn_core/src/ast/ast_nodes.rs#L639C1-L645C3) for a while and haven't come across an unrecognized node since :) So I thought I'll share it with ya!