### PR TITLE
feat: better error messages for incompatible versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,3 +62,5 @@ yansi = "1.0"
 # async
 futures-util = "0.3"
 tokio = { version = "1.35", features = ["rt-multi-thread"] }
+
+snapbox = "0.6.9"

--- a/crates/compilers/Cargo.toml
+++ b/crates/compilers/Cargo.toml
@@ -61,6 +61,7 @@ fd-lock = "4.0.0"
 tokio = { version = "1.35", features = ["rt-multi-thread", "macros"] }
 reqwest = "0.12"
 tempfile = "3.9"
+snapbox.workspace = true
 foundry-compilers-core = { workspace = true, features = ["test-utils"] }
 
 [features]

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -633,7 +633,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
 
         let mut msg = "Found incompatible versions:\n".white().to_string();
         self.format_imports_list(idx, nodes.into_iter().collect(), &mut msg).unwrap();
-        Err(format!("Found incompatible versions:\n{msg}"))
+        Err(msg)
     }
 
     fn input_nodes_by_language(&self) -> HashMap<D::Language, Vec<usize>> {

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -634,7 +634,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
 
         let mut msg = String::new();
         self.format_imports_list(idx, nodes[1..].to_vec(), &mut msg).unwrap();
-        Err(format!("Found incompatible versions:\n{msg}"));
+        Err(format!("Found incompatible versions:\n{msg}"))
     }
 
     fn input_nodes_by_language(&self) -> HashMap<D::Language, Vec<usize>> {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub type Result<T> = std::result::Result<T, SolcError>;
+pub type Result<T, E = SolcError> = std::result::Result<T, E>;
 
 #[allow(unused_macros)]
 #[macro_export]

--- a/test-data/incompatible-pragmas/src/A.sol
+++ b/test-data/incompatible-pragmas/src/A.sol
@@ -1,0 +1,3 @@
+pragma solidity 0.8.25;
+
+import "./B.sol";

--- a/test-data/incompatible-pragmas/src/B.sol
+++ b/test-data/incompatible-pragmas/src/B.sol
@@ -1,0 +1,1 @@
+import "./C.sol";

--- a/test-data/incompatible-pragmas/src/C.sol
+++ b/test-data/incompatible-pragmas/src/C.sol
@@ -1,0 +1,1 @@
+pragma solidity 0.7.0;


### PR DESCRIPTION
Closes https://github.com/foundry-rs/compilers/issues/43

Adds logic to resolve which nodes actually caused the resolver failure. This provides us access to ids of actually incompatible nodes in `format_imports_list` fn. 

It will now highlight sources causing failure in red