### PR TITLE
fix: include `evm.legacyAssembly` output

### DIFF
--- a/crates/artifacts/solc/src/configurable.rs
+++ b/crates/artifacts/solc/src/configurable.rs
@@ -23,6 +23,8 @@ pub struct ConfigurableContractArtifact {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assembly: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_assembly: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opcodes: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method_identifiers: Option<BTreeMap<String, String>>,

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -265,7 +265,7 @@ impl ParsedSource for SolData {
         _paths: &crate::ProjectPathsConfig<C>,
         _include_paths: &mut BTreeSet<PathBuf>,
     ) -> Result<Vec<PathBuf>> {
-        return Ok(self.imports.iter().map(|i| i.data().path().to_path_buf()).collect_vec());
+        Ok(self.imports.iter().map(|i| i.data().path().to_path_buf()).collect_vec())
     }
 
     fn language(&self) -> Self::Language {

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -188,6 +188,7 @@ fn can_compile_configured() {
             ir: true,
             ir_optimized: true,
             opcodes: true,
+            legacy_assembly: true,
             ..Default::default()
         },
         ..Default::default()
@@ -202,6 +203,8 @@ fn can_compile_configured() {
     assert!(artifact.ir.is_some());
     assert!(artifact.ir_optimized.is_some());
     assert!(artifact.opcodes.is_some());
+    assert!(artifact.opcodes.is_some());
+    assert!(artifact.legacy_assembly.is_some());
 }
 
 #[test]


### PR DESCRIPTION
adding support for `legacyAssembly` artifact output, https://github.com/foundry-rs/foundry/issues/8977