### PR TITLE
feat: better extra_args handling

### DIFF
--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -278,7 +278,7 @@ pub trait Compiler: Send + Sync + Clone {
 
 pub(crate) fn cache_version(
     path: PathBuf,
-    args: &Vec<String>,
+    args: &[String],
     f: impl FnOnce(&Path) -> Result<Version>,
 ) -> Result<Version> {
     #[allow(clippy::complexity)]
@@ -295,7 +295,7 @@ pub(crate) fn cache_version(
 
     let version = f(&path)?;
 
-    lock.entry(path).or_default().insert(args.clone(), version.clone());
+    lock.entry(path).or_default().insert(args.to_vec(), version.clone());
 
     Ok(version)
 }

--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -281,6 +281,7 @@ pub(crate) fn cache_version(
     args: &Vec<String>,
     f: impl FnOnce(&Path) -> Result<Version>,
 ) -> Result<Version> {
+    #[allow(clippy::complexity)]
     static VERSION_CACHE: OnceLock<Mutex<HashMap<PathBuf, HashMap<Vec<String>, Version>>>> =
         OnceLock::new();
     let mut lock = VERSION_CACHE

--- a/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/src/compilers/solc/compiler.rs
@@ -447,7 +447,7 @@ impl Solc {
     /// Invokes `solc --version` and parses the output as a SemVer [`Version`].
     #[instrument(level = "debug", skip_all)]
     pub fn version(solc: impl Into<PathBuf>) -> Result<Version> {
-        Self::version_with_args(solc, &Vec::new())
+        Self::version_with_args(solc, &[])
     }
 
     /// Invokes `solc --version` and parses the output as a SemVer [`Version`].

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -55,7 +55,7 @@ impl Compiler for SolcCompiler {
         solc.base_path.clone_from(&input.cli_settings.base_path);
         solc.allow_paths.clone_from(&input.cli_settings.allow_paths);
         solc.include_paths.clone_from(&input.cli_settings.include_paths);
-        solc.extra_args.clone_from(&input.cli_settings.extra_args);
+        solc.extra_args.extend_from_slice(&input.cli_settings.extra_args);
 
         let solc_output = solc.compile(&input.input)?;
 

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -166,7 +166,7 @@ impl Vyper {
     /// Invokes `vyper --version` and parses the output as a SemVer [`Version`].
     #[instrument(level = "debug", skip_all)]
     pub fn version(vyper: impl Into<PathBuf>) -> Result<Version> {
-        crate::cache_version(vyper.into(), &Vec::new(), |vyper| {
+        crate::cache_version(vyper.into(), &[], |vyper| {
             let mut cmd = Command::new(vyper);
             cmd.arg("--version")
                 .stdin(Stdio::piped())

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -166,7 +166,7 @@ impl Vyper {
     /// Invokes `vyper --version` and parses the output as a SemVer [`Version`].
     #[instrument(level = "debug", skip_all)]
     pub fn version(vyper: impl Into<PathBuf>) -> Result<Version> {
-        crate::cache_version(vyper.into(), |vyper| {
+        crate::cache_version(vyper.into(), &Vec::new(), |vyper| {
             let mut cmd = Command::new(vyper);
             cmd.arg("--version")
                 .stdin(Stdio::piped())


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/8997

Adds `Solc` constructor for creating solc instances with arguments. Changes `extra_args` to being prepended to actual solc arguments instead of appended as for now.

This allows us to use eof binary through `Solc::new_with_args("docker", ["run", ... ])`

We didn't end up using those for `--eof-version`, so this shouldn't break anything. Will add a test for this in scope `--eof` flag on foundry side