### PR TITLE
fix: accept partial first sourcemap element

### DIFF
--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -14,6 +14,8 @@
 
 // <https://github.com/tokio-rs/tracing/blob/master/tracing-core/src/dispatch.rs>
 
+#![allow(static_mut_refs)] // TODO
+
 use foundry_compilers_artifacts::remappings::Remapping;
 use semver::Version;
 use std::{


### PR DESCRIPTION
Fixes https://github.com/foundry-rs/foundry/issues/8986

Looks like solc can emit partial first elements in source map which we were rejecting