### PR TITLE
chore: allow adding vyper sources with `add_raw_source` w/ `.vy` / `.vyi` extension

### DIFF
--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -98,7 +98,7 @@ pub(crate) fn create_contract_file(path: &Path, content: impl AsRef<str>) -> Res
 
 fn contract_file_name(name: &str) -> String {
     let name = name.trim();
-    if name.ends_with(".sol") {
+    if name.ends_with(".sol") || name.ends_with(".vy") {
         name.to_string()
     } else {
         format!("{name}.sol")

--- a/crates/compilers/src/project_util/mod.rs
+++ b/crates/compilers/src/project_util/mod.rs
@@ -98,7 +98,7 @@ pub(crate) fn create_contract_file(path: &Path, content: impl AsRef<str>) -> Res
 
 fn contract_file_name(name: &str) -> String {
     let name = name.trim();
-    if name.ends_with(".sol") || name.ends_with(".vy") {
+    if name.ends_with(".sol") || name.ends_with(".vy") || name.ends_with(".vyi") {
         name.to_string()
     } else {
         format!("{name}.sol")


### PR DESCRIPTION
Required for https://github.com/foundry-rs/foundry/pull/7909

Related: https://github.com/foundry-rs/foundry/blob/32863e7b19bc07304ad0cac2e2b018fdde295f94/crates/forge/bin/cmd/compiler.rs#L318-L319

Allow adding Vyper sources with `add_raw_source` w/ `.vy` / `.vyi` extension so it can be compiled as part of the script