### PR TITLE
chore: fix deny (add `ZLib` exception)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -56,6 +56,7 @@ allow = [
     "LicenseRef-webpki",
     "BSL-1.0",
     "Unicode-3.0",
+    "Zlib",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses


### PR DESCRIPTION
adds `zlib`

Related: https://github.com/foundry-rs/foundry/blob/6f7c1f72f8c3361f1e738296a0ec634c099c8a7c/deny.toml#L56

Related: https://github.com/foundry-rs/compilers/actions/runs/11327859489