### PR TITLE
fix: correctly handle b as pre-release in Vyper version

### DIFF
--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -177,7 +177,7 @@ impl Vyper {
             trace!(?output);
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                Ok(Version::from_str(&stdout.trim().replace("rc", "-rc"))?)
+                Ok(Version::from_str(&stdout.trim().replace("rc", "-rc").replace("b", "-b"))?)
             } else {
                 Err(SolcError::solc_output(&output))
             }

--- a/crates/compilers/src/compilers/vyper/mod.rs
+++ b/crates/compilers/src/compilers/vyper/mod.rs
@@ -177,7 +177,9 @@ impl Vyper {
             trace!(?output);
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                Ok(Version::from_str(&stdout.trim().replace("rc", "-rc").replace("b", "-b"))?)
+                Ok(Version::from_str(
+                    &stdout.trim().replace("rc", "-rc").replace("b", "-b").replace("a", "-a"),
+                )?)
             } else {
                 Err(SolcError::solc_output(&output))
             }


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/9123

I've done similar workaround for rc before. For semver we need those to be prepended by a dash.

PEP440 pragmas are still might not be parsed correctly but this is not a showstopper as we're just ignoring them right now, and user would see a vyper error in case of mismatch. 
