### PR TITLE
fix: sanitize `settings.optimizer.details.inliner`

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -2229,4 +2229,20 @@ mod tests {
         let content = fs::read_to_string(path).unwrap();
         let _output: CompilerOutput = serde_json::from_str(&content).unwrap();
     }
+
+    // <https://github.com/foundry-rs/foundry/issues/9322>
+    #[test]
+    fn can_sanitize_optimizer_inliner() {
+        let version: Version = "0.8.4".parse().unwrap();
+        let settings = Settings::default().with_via_ir_minimum_optimization();
+
+        let input =
+            SolcInput { language: SolcLanguage::Solidity, sources: Default::default(), settings };
+
+        let i = input.clone().sanitized(&version);
+        assert!(i.settings.optimizer.details.unwrap().inliner.is_none());
+
+        let i = input.sanitized(&Version::new(0, 8, 5));
+        assert_eq!(i.settings.optimizer.details.unwrap().inliner, Some(false));
+    }
 }

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -314,6 +314,14 @@ impl Settings {
             self.via_ir = None;
         }
 
+        const V0_8_5: Version = Version::new(0, 8, 5);
+        if *version < V0_8_5 {
+            // introduced in 0.8.5 <https://github.com/ethereum/solidity/releases/tag/v0.8.5>
+            if let Some(optimizer_details) = &mut self.optimizer.details {
+                optimizer_details.inliner = None;
+            }
+        }
+
         const V0_8_7: Version = Version::new(0, 8, 7);
         if *version < V0_8_7 {
             // lower the disable version from 0.8.10 to 0.8.7, due to `divModNoSlacks`,
@@ -467,8 +475,7 @@ impl Settings {
         self.via_ir = Some(true);
         self.optimizer.details = Some(OptimizerDetails {
             peephole: Some(false),
-            // Set to None as it is only supported for solc starting from 0.8.5.
-            inliner: None,
+            inliner: Some(false),
             jumpdest_remover: Some(false),
             order_literals: Some(false),
             deduplicate: Some(false),

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -467,7 +467,8 @@ impl Settings {
         self.via_ir = Some(true);
         self.optimizer.details = Some(OptimizerDetails {
             peephole: Some(false),
-            inliner: Some(false),
+            // Set to None as it is only supported for solc starting from 0.8.5.
+            inliner: None,
             jumpdest_remover: Some(false),
             order_literals: Some(false),
             deduplicate: Some(false),


### PR DESCRIPTION
Ref https://github.com/foundry-rs/foundry/issues/9322#issuecomment-2480484349
https://github.com/ethereum/solidity/issues/15576#issuecomment-2480385494

Set inliner to None since it is properly supported from 0.8.5 version( see `Standard JSON: Properly allow the inliner setting under settings.optimizer.details` https://soliditylang.org/blog/2021/06/10/solidity-0.8.5-release-announcement/)