### PR TITLE
fix: `collect_contract_names`

### DIFF
--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -382,7 +382,7 @@ impl<T: ArtifactOutput, C: Compiler> Project<C, T> {
         let graph = Graph::<C::ParsedSource>::resolve(&self.paths)?;
         let mut contracts: HashMap<String, Vec<PathBuf>> = HashMap::new();
         if !graph.is_empty() {
-            for node in graph.nodes(0) {
+            for node in &graph.nodes {
                 for contract_name in node.data.contract_names() {
                     contracts
                         .entry(contract_name.clone())

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -205,7 +205,7 @@ impl<D> GraphEdges<D> {
 #[derive(Debug)]
 pub struct Graph<D = SolData> {
     /// all nodes in the project, a `Node` represents a single file
-    nodes: Vec<Node<D>>,
+    pub nodes: Vec<Node<D>>,
     /// relationship of the nodes
     edges: GraphEdges<D>,
     /// the root of the project this graph represents


### PR DESCRIPTION
This should go over all nodes vs just the first one and its dependencies