### PR TITLE
Fix minor grammatical issue in project documentation

### DIFF
--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -10,7 +10,7 @@
 //!      compatible with, solidity version pragma.
 //!   2. A dependency can be imported from any directory, see `Remappings`
 //!
-//! Finding all dependencies is fairly simple, we're simply doing a DFS, starting the source
+//! Finding all dependencies is fairly simple, we're simply doing a DFS, starting from the source
 //! contracts
 //!
 //! ## Solc version auto-detection


### PR DESCRIPTION
### Description:

This pull request addresses a minor grammatical issue in the project documentation regarding the description of the dependency resolution algorithm. Specifically, the following sentence:

> Finding all dependencies is fairly simple, we're simply doing a DFS, starting the source contracts.

#### Issue:
The sentence is missing the preposition "from," making it grammatically incorrect and slightly harder to read. The corrected version is:

> Finding all dependencies is fairly simple, we're simply doing a DFS, starting **from** the source contracts.

#### Importance:
While this is a small change, improving the grammar enhances the readability and professionalism of the documentation. Clear documentation is especially important for developers who rely on it to understand the dependency resolution logic and its implementation.

#### Change Summary:
- Added the preposition "from" to the sentence describing the DFS algorithm for finding dependencies.

#### Before:
> Finding all dependencies is fairly simple, we're simply doing a DFS, starting the source contracts.

#### After:
> Finding all dependencies is fairly simple, we're simply doing a DFS, starting **from** the source contracts.

---

Thank you for maintaining this great project! Please let me know if additional changes are required. 😊