### PR TITLE
Fix Typographical Error Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ the best of your ability. Do not worry if you cannot answer every detail, just
 fill in what you can.
 
 The two most important pieces of information we need in order to properly
-evaluate the report is a description of the behavior you are seeing and a simple
+evaluate the report are a description of the behavior you are seeing and a simple
 test case we can use to recreate the problem on our own. If we cannot recreate
 the issue, it becomes impossible for us to fix.
 


### PR DESCRIPTION
**Description:**  
In the section describing the evaluation process of bug reports, there was a grammatical mistake. The sentence:

_"The two most important pieces of information we need in order to properly evaluate the report is a description..."_

incorrectly used "is" instead of "are," which caused a subject-verb agreement error. Since "pieces of information" is plural, the correct form is "are." This fix ensures proper grammar and clarity in the documentation. The updated sentence is now:

_"The two most important pieces of information we need in order to properly evaluate the report **are** a description..."_

Correcting this error helps maintain the professionalism and clarity of the documentation.