### PR TITLE
fix: EvmVersion `from_str`

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -957,8 +957,8 @@ impl FromStr for EvmVersion {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "homestead" => Ok(Self::Homestead),
-            "tangerineWhistle" => Ok(Self::TangerineWhistle),
-            "spuriousDragon" => Ok(Self::SpuriousDragon),
+            "tangerineWhistle" | "tangerinewhistle" => Ok(Self::TangerineWhistle),
+            "spuriousDragon" | "spuriousdragon" => Ok(Self::SpuriousDragon),
             "byzantium" => Ok(Self::Byzantium),
             "constantinople" => Ok(Self::Constantinople),
             "petersburg" => Ok(Self::Petersburg),


### PR DESCRIPTION
Currently, `EvmVersion` won't get deserialized for `spuriousdragon` and `tangerinewhistle`. 

This can be reproduced using:
```
cast run 0x6b5ca68eb4c4b38690ec12ba9f85409b618759646e50ab53b28f9d67f74978fc --rpc-url=https://rpc.ankr.com/eth --evm-version spuriousDragon
Error: failed to extract foundry config:
foundry config error: Unknown evm version: spuriousdragon for key "default.evm_version" in RunArgs for setting `evm_version`
```

Solution:

Handle camel case and lowercase