### PR TITLE
feat: better artifact filenames for different profiles

### DIFF
--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -732,8 +732,9 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> Art
         sources: &VersionedSourceFiles,
         layout: &ProjectPathsConfig<CP>,
         ctx: OutputContext<'_>,
+        primary_profiles: &HashMap<PathBuf, &str>,
     ) -> Result<Artifacts<Self::Artifact>> {
-        self.artifacts_handler().on_output(contracts, sources, layout, ctx)
+        self.artifacts_handler().on_output(contracts, sources, layout, ctx, primary_profiles)
     }
 
     fn handle_artifacts(
@@ -797,8 +798,15 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> Art
         sources: &VersionedSourceFiles,
         ctx: OutputContext<'_>,
         layout: &ProjectPathsConfig<CP>,
+        primary_profiles: &HashMap<PathBuf, &str>,
     ) -> Artifacts<Self::Artifact> {
-        self.artifacts_handler().output_to_artifacts(contracts, sources, ctx, layout)
+        self.artifacts_handler().output_to_artifacts(
+            contracts,
+            sources,
+            ctx,
+            layout,
+            primary_profiles,
+        )
     }
 
     fn standalone_source_file_to_artifact(

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -72,6 +72,26 @@ mod tree;
 pub use parse::SolImportAlias;
 pub use tree::{print, Charset, TreeOptions};
 
+/// Container for result of version and profile resolution of sources contained in [`Graph`].
+#[derive(Debug)]
+pub struct ResolvedSources<'a, C: Compiler> {
+    /// Resolved set of sources.
+    ///
+    /// Mapping from language to a [`Vec`] of compiler inputs consisting of version, sources set
+    /// and settings.
+    pub sources: VersionedSources<'a, C::Language, C::Settings>,
+    /// A mapping from a source file path to the primary profile name selected for it.
+    ///
+    /// This is required because the same source file might be compiled with multiple different
+    /// profiles if it's present as a dependency for other sources. We want to keep a single name
+    /// of the profile which was chosen specifically for each source so that we can default to it.
+    /// Right now, this is used when generating artifact names, "primary" artifact will never have
+    /// a profile suffix.
+    pub primary_profiles: HashMap<PathBuf, &'a str>,
+    /// Graph edges.
+    pub edges: GraphEdges<C::ParsedSource>,
+}
+
 /// The underlying edges of the graph which only contains the raw relationship data.
 ///
 /// This is kept separate from the `Graph` as the `Node`s get consumed when the `Solc` to `Sources`
@@ -468,14 +488,13 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
     ///
     /// First we determine the compatible version for each input file (from sources and test folder,
     /// see `Self::resolve`) and then we add all resolved library imports.
-    pub fn into_sources_by_version<C, T, S>(
+    pub fn into_sources_by_version<C, T>(
         self,
         project: &Project<C, T>,
-    ) -> Result<(VersionedSources<'_, L, S>, GraphEdges<D>)>
+    ) -> Result<ResolvedSources<'_, C>>
     where
         T: ArtifactOutput<CompilerContract = C::CompilerContract>,
-        S: CompilerSettings,
-        C: Compiler<ParsedSource = D, Language = L, Settings = S>,
+        C: Compiler<ParsedSource = D, Language = L>,
     {
         /// insert the imports of the given node into the sources map
         /// There can be following graph:
@@ -514,6 +533,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
         let mut all_nodes = nodes.into_iter().enumerate().collect::<HashMap<_, _>>();
 
         let mut resulted_sources = HashMap::new();
+        let mut default_profiles = HashMap::new();
 
         let profiles = project.settings_profiles().collect::<Vec<_>>();
 
@@ -534,6 +554,8 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
                         // set
                         let (path, source) =
                             all_nodes.get(&idx).cloned().expect("node is preset. qed");
+
+                        default_profiles.insert(path.clone(), profiles[profile_idx].0);
                         sources.insert(path, source);
                         insert_imports(
                             idx,
@@ -550,7 +572,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
             resulted_sources.insert(language, versioned_sources);
         }
 
-        Ok((resulted_sources, edges))
+        Ok(ResolvedSources { sources: resulted_sources, primary_profiles: default_profiles, edges })
     }
 
     /// Writes the list of imported files into the given formatter:


### PR DESCRIPTION
Closes https://github.com/foundry-rs/foundry/issues/9722

This PR introduces a concept of "primary" profile. Primary profile is the one which we've chosen for input source when analyzing it on its own (i.e not as a dependency of other contract). That way `Counter.json` would always correspond to an artifact compiled with the default profile if it was possible.