### PR TITLE
feat: impl `.path(&self)` for `ContractInfo`

### DIFF
--- a/crates/compilers/src/compile/output/info.rs
+++ b/crates/compilers/src/compile/output/info.rs
@@ -1,6 +1,6 @@
 //! Commonly used identifiers for contracts in the compiled output.
 
-use std::{borrow::Cow, fmt, str::FromStr};
+use std::{borrow::Cow, fmt, path::Path, str::FromStr};
 
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 #[error("{0}")]
@@ -39,6 +39,11 @@ impl ContractInfo {
     /// ```
     pub fn new(info: &str) -> Self {
         info.parse().unwrap_or_else(|_| Self { path: None, name: info.to_string() })
+    }
+
+    /// Returns the path to the contract source file if provided.
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref().map(Path::new)
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/foundry-rs/foundry/pull/9770#discussion_r1934652943

Smol convenience fn for `ContractInfo` to retrieve the `Path`.