### PR TITLE
fix: allow top level event declarations

### DIFF
--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -57,6 +57,7 @@ node_group! {
     VariableDeclaration,
     EnumDefinition,
     ErrorDefinition,
+    EventDefinition,
     FunctionDefinition,
     StructDefinition,
     UserDefinedValueTypeDefinition,

--- a/crates/artifacts/solc/src/ast/visitor.rs
+++ b/crates/artifacts/solc/src/ast/visitor.rs
@@ -99,6 +99,9 @@ impl_walk!(SourceUnitPart, |part, visitor| {
         SourceUnitPart::ErrorDefinition(error) => {
             error.walk(visitor);
         }
+        SourceUnitPart::EventDefinition(event) => {
+            event.walk(visitor);
+        }
         SourceUnitPart::StructDefinition(struct_) => {
             struct_.walk(visitor);
         }

--- a/crates/compilers/src/flatten.rs
+++ b/crates/compilers/src/flatten.rs
@@ -320,7 +320,7 @@ impl Flattener {
             let mut ids = ids.clone().into_iter().collect::<Vec<_>>();
             if needs_rename {
                 // `loc.path` is expected to be different for each id because there can't be 2
-                // top-level eclarations with the same name in the same file.
+                // top-level declarations with the same name in the same file.
                 //
                 // Sorting by index loc.path in sorted files to make the renaming process
                 // deterministic.

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -4113,3 +4113,44 @@ contract SimpleContract {}
         ]
     );
 }
+
+// <https://github.com/foundry-rs/foundry/issues/9876>
+#[test]
+fn can_flatten_top_level_event_declaration() {
+    let project = TempProject::<MultiCompiler>::dapptools().unwrap();
+
+    let target = project
+        .add_source(
+            "A",
+            r#"pragma solidity ^0.8.10;
+import "./B.sol";
+contract A { }
+"#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "B",
+            r#"
+event TestEvent();
+"#,
+        )
+        .unwrap();
+
+    test_flatteners(&project, &target, |result| {
+        assert_eq!(
+            result,
+            r"pragma solidity ^0.8.10;
+
+// src/B.sol
+
+event TestEvent();
+
+// src/A.sol
+
+contract A { }
+"
+        );
+    });
+}


### PR DESCRIPTION
- ref https://github.com/foundry-rs/foundry/issues/9876: add ErrorDefinition as part of SourceUnitPart group