### PR TITLE
feat: add osaka evm version

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -818,6 +818,7 @@ pub enum EvmVersion {
     #[default]
     Cancun,
     Prague,
+    Osaka,
 }
 
 impl EvmVersion {
@@ -900,6 +901,7 @@ impl EvmVersion {
             Self::Shanghai => "shanghai",
             Self::Cancun => "cancun",
             Self::Prague => "prague",
+            Self::Osaka => "osaka",
         }
     }
 
@@ -969,6 +971,7 @@ impl FromStr for EvmVersion {
             "shanghai" => Ok(Self::Shanghai),
             "cancun" => Ok(Self::Cancun),
             "prague" => Ok(Self::Prague),
+            "osaka" => Ok(Self::Osaka),
             s => Err(format!("Unknown evm version: {s}")),
         }
     }

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -66,6 +66,10 @@ pub const CANCUN_SOLC: Version = Version::new(0, 8, 24);
 /// <https://soliditylang.org/blog/2024/09/04/solidity-0.8.27-release-announcement>
 pub const PRAGUE_SOLC: Version = Version::new(0, 8, 27);
 
+/// Osaka support
+/// <https://soliditylang.org/blog/2025/03/12/solidity-0.8.29-release-announcement>
+pub const OSAKA_SOLC: Version = Version::new(0, 8, 29);
+
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
 pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =
     Lazy::new(|| VersionReq::parse(">=0.6.9").unwrap());


### PR DESCRIPTION
ref https://soliditylang.org/blog/2025/03/12/solidity-0.8.29-release-announcement

if configured opts into experimental EOF support

ref https://github.com/foundry-rs/foundry/issues/10064