### PR TITLE
deps: bump solar 0.1.2 -> solar 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
 similar-asserts = "1"
-solar-parse = { version = "=0.1.2", default-features = false }
-solar-sema = { version = "=0.1.2", default-features = false }
+solar-parse = { version = "=0.1.3", default-features = false }
+solar-sema = { version = "=0.1.3", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false }
 tempfile = "3.9"
 thiserror = "2"


### PR DESCRIPTION
Required for https://github.com/foundry-rs/foundry/pull/10454 to align alloy versions