### PR TITLE
Support `transient` in `StorageLocation`

### DIFF
--- a/crates/artifacts/solc/src/ast/misc.rs
+++ b/crates/artifacts/solc/src/ast/misc.rs
@@ -92,6 +92,7 @@ pub enum StorageLocation {
     Default,
     Memory,
     Storage,
+    Transient,
 }
 
 /// Visibility specifier.


### PR DESCRIPTION
Trivial patch. The new variant `transient` seems missing.