### PR TITLE
fix: update Tera documentation link in cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
 """
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/foundry-rs/compilers/releases/tag/v{{ version | trim_start_matches(pat="v") }}) - {{ timestamp | date(format="%Y-%m-%d") }}


### PR DESCRIPTION
Replaced the outdated or broken link to the Tera template engine documentation in cliff.toml with the current one: https://keats.github.io/tera/docs/#introduction

This change helps users quickly find up-to-date documentation for the template syntax used in the changelog configuration.