### PR TITLE
Some fields are optional during `"stopAfter":"parsing"`

### DIFF
--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -178,7 +178,7 @@ ast_node!(
         fully_implemented: bool,
         linearized_base_contracts: Vec<usize>,
         nodes: Vec<ContractDefinitionPart>,
-        scope: usize,
+        scope: Option<usize>,
         #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         used_errors: Vec<usize>,
         #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
@@ -536,7 +536,7 @@ ast_node!(
         #[serde(default)]
         mutability: Option<Mutability>,
         overrides: Option<OverrideSpecifier>,
-        scope: usize,
+        scope: Option<usize>,
         storage_location: StorageLocation,
         type_descriptions: TypeDescriptions,
         type_name: Option<TypeName>,
@@ -713,7 +713,7 @@ ast_node!(
         overrides: Option<OverrideSpecifier>,
         parameters: ParameterList,
         return_parameters: ParameterList,
-        scope: usize,
+        scope: Option<usize>,
         visibility: Visibility,
         /// The kind of function this node defines. Only valid for Solidity versions 0.5.x and
         /// above.
@@ -1028,7 +1028,7 @@ ast_node!(
         name_location: Option<SourceLocation>,
         canonical_name: String,
         members: Vec<VariableDeclaration>,
-        scope: usize,
+        scope: Option<usize>,
         visibility: Visibility,
     }
 );
@@ -1082,7 +1082,7 @@ ast_node!(
         file: String,
         #[serde(default, with = "serde_helpers::display_from_str_opt")]
         name_location: Option<SourceLocation>,
-        scope: usize,
+        scope: Option<usize>,
         source_unit: usize,
         symbol_aliases: Vec<SymbolAlias>,
         unit_alias: String,

--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -177,6 +177,8 @@ ast_node!(
         documentation: Option<Documentation>,
         // Not available when "stopAfter": "parsing" is specified.
         fully_implemented: Option<bool>,
+        // Not available when "stopAfter": "parsing" is specified.
+        #[serde(default)]
         linearized_base_contracts: Vec<usize>,
         nodes: Vec<ContractDefinitionPart>,
         // Not available when "stopAfter": "parsing" is specified.

--- a/crates/artifacts/solc/src/ast/mod.rs
+++ b/crates/artifacts/solc/src/ast/mod.rs
@@ -175,9 +175,11 @@ ast_node!(
         #[serde(rename = "contractKind")]
         kind: ContractKind,
         documentation: Option<Documentation>,
-        fully_implemented: bool,
+        // Not available when "stopAfter": "parsing" is specified.
+        fully_implemented: Option<bool>,
         linearized_base_contracts: Vec<usize>,
         nodes: Vec<ContractDefinitionPart>,
+        // Not available when "stopAfter": "parsing" is specified.
         scope: Option<usize>,
         #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         used_errors: Vec<usize>,
@@ -536,6 +538,7 @@ ast_node!(
         #[serde(default)]
         mutability: Option<Mutability>,
         overrides: Option<OverrideSpecifier>,
+        // Not available when "stopAfter": "parsing" is specified.
         scope: Option<usize>,
         storage_location: StorageLocation,
         type_descriptions: TypeDescriptions,
@@ -713,6 +716,7 @@ ast_node!(
         overrides: Option<OverrideSpecifier>,
         parameters: ParameterList,
         return_parameters: ParameterList,
+        // Not available when "stopAfter": "parsing" is specified.
         scope: Option<usize>,
         visibility: Visibility,
         /// The kind of function this node defines. Only valid for Solidity versions 0.5.x and
@@ -1028,6 +1032,7 @@ ast_node!(
         name_location: Option<SourceLocation>,
         canonical_name: String,
         members: Vec<VariableDeclaration>,
+        // Not available when "stopAfter": "parsing" is specified.
         scope: Option<usize>,
         visibility: Visibility,
     }
@@ -1082,6 +1087,7 @@ ast_node!(
         file: String,
         #[serde(default, with = "serde_helpers::display_from_str_opt")]
         name_location: Option<SourceLocation>,
+        // Not available when "stopAfter": "parsing" is specified.
         scope: Option<usize>,
         source_unit: usize,
         symbol_aliases: Vec<SymbolAlias>,


### PR DESCRIPTION
Trivial patch.

Reproduce:

```bash
echo '{"language":"Solidity","sources":{"test.sol":{"content":"contract TT {\\n    function main() public {}\\n}"}},"settings":{"stopAfter":"parsing","optimizer":{"enabled":false,"runs":200},"outputSelection":{"*":{"":["ast"],"*":[]}},"viaIR":true,"libraries":{}}}' | solc --standard-json
```

Since there is no semantics analysis when stopping after parsing, `scope` along with a few other fields are not available and this PR marks all `scope` to be optional.