### PR TITLE
chore: clean up error! calls

### DIFF
--- a/crates/compilers/src/compilers/solc/compiler.rs
+++ b/crates/compilers/src/compilers/solc/compiler.rs
@@ -54,7 +54,7 @@ pub static RELEASES: std::sync::LazyLock<(svm::Releases, Vec<Version>, bool)> =
                 (releases, sorted_versions, true)
             }
             Err(err) => {
-                error!("{:?}", err);
+                error!("failed to deserialize SVM static RELEASES JSON: {err}");
                 Default::default()
             }
         }

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -963,7 +963,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
         } else {
             let s = errors.join("\n");
             debug!("failed to resolve settings: {s}");
-            return Err(SolcError::msg(s));
+           Err(SolcError::msg(s))
         }
     }
 

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -917,8 +917,9 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
                         .collect(),
                 );
             } else {
-                error!("failed to resolve versions");
-                return Err(SolcError::msg(errors.join("\n")));
+                let s = errors.join("\n");
+                debug!("failed to resolve versions: {s}");
+                return Err(SolcError::msg(s));
             }
         }
 
@@ -960,8 +961,9 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
         if errors.is_empty() {
             Ok(resulted_sources)
         } else {
-            error!("failed to resolve settings");
-            Err(SolcError::msg(errors.join("\n")))
+            let s = errors.join("\n");
+            debug!("failed to resolve settings: {s}");
+            return Err(SolcError::msg(s));
         }
     }
 

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -963,7 +963,7 @@ impl<L: Language, D: ParsedSource<Language = L>> Graph<D> {
         } else {
             let s = errors.join("\n");
             debug!("failed to resolve settings: {s}");
-           Err(SolcError::msg(s))
+            Err(SolcError::msg(s))
         }
     }
 


### PR DESCRIPTION
I got a `ERROR` log when using `forge flatten` with no extra message, and the error itself gets ignored with a fallback