### PR TITLE
chore: add language matcher on `MultiCompilerLanguage`

### DIFF
--- a/crates/compilers/src/compilers/multi.rs
+++ b/crates/compilers/src/compilers/multi.rs
@@ -66,6 +66,16 @@ pub enum MultiCompilerLanguage {
     Vyper(VyperLanguage),
 }
 
+impl MultiCompilerLanguage {
+    pub fn is_vyper(&self) -> bool {
+        matches!(self, Self::Vyper(_))
+    }
+
+    pub fn is_solc(&self) -> bool {
+        matches!(self, Self::Solc(_))
+    }
+}
+
 impl From<SolcLanguage> for MultiCompilerLanguage {
     fn from(language: SolcLanguage) -> Self {
         Self::Solc(language)


### PR DESCRIPTION
This simplifies conditional language logic where previously:

```rust
 matches!(language, MultiCompilerLanguage::Vyper(_))
 ```
 
 now becomes
 
 ```rust
language.is_vyper()
```