### PR TITLE
Add missing nodetypes on serialize/deserialize statement

### DIFF
--- a/crates/artifacts/solc/src/ast/lowfidelity.rs
+++ b/crates/artifacts/solc/src/ast/lowfidelity.rs
@@ -289,6 +289,9 @@ impl serde::Serialize for NodeType {
             NodeType::ParameterList => serializer.serialize_str("ParameterList"),
             NodeType::TryCatchClause => serializer.serialize_str("TryCatchClause"),
             NodeType::ModifierInvocation => serializer.serialize_str("ModifierInvocation"),
+            NodeType::UserDefinedTypeName => serializer.serialize_str("UserDefinedTypeName"),
+            NodeType::ArrayTypeName => serializer.serialize_str("ArrayTypeName"),
+            NodeType::Mapping => serializer.serialize_str("Mapping"),
             NodeType::Other(s) => serializer.serialize_str(s),
         }
     }
@@ -368,6 +371,9 @@ impl<'de> serde::Deserialize<'de> for NodeType {
             "ParameterList" => NodeType::ParameterList,
             "TryCatchClause" => NodeType::TryCatchClause,
             "ModifierInvocation" => NodeType::ModifierInvocation,
+            "UserDefinedTypeName" => NodeType::UserDefinedTypeName,
+            "ArrayTypeName" => NodeType::ArrayTypeName,
+            "Mapping" => NodeType::Mapping,
             _ => NodeType::Other(s),
         })
     }


### PR DESCRIPTION
As part of this issue https://github.com/foundry-rs/compilers/issues/280 two changes were added. One to add the new types https://github.com/foundry-rs/compilers/pull/282 and another one to add custom deserialise functions (it looks to me committed to [main](https://github.com/foundry-rs/compilers/commit/9920c749f30f39f27f605ce25d69bf9483495f1f) directly?

But the second one was added without rebasing the first change so the match statement for the node types fails to account for the new types.
