### PR TITLE
Remove duplicate assembly check in is_dirty

### DIFF
--- a/crates/compilers/src/artifact_output/configurable.rs
+++ b/crates/compilers/src/artifact_output/configurable.rs
@@ -377,9 +377,6 @@ impl ArtifactOutput for ConfigurableArtifacts {
         if assembly && artifact.assembly.is_none() {
             return Ok(true);
         }
-        if assembly && artifact.assembly.is_none() {
-            return Ok(true);
-        }
         if legacy_assembly && artifact.legacy_assembly.is_none() {
             return Ok(true);
         }


### PR DESCRIPTION
This commit removes a redundant check for assembly in the is_dirty method, leaving only a single, correct check for assembly. No other logic was changed.