### PR TITLE
fix(flatten): sort by loc path and loc start

### DIFF
--- a/crates/compilers/src/flatten.rs
+++ b/crates/compilers/src/flatten.rs
@@ -317,10 +317,10 @@ impl Flattener {
                 // `loc.path` is expected to be different for each id because there can't be 2
                 // top-level declarations with the same name in the same file.
                 //
-                // Sorting by index loc.path in sorted files to make the renaming process
-                // deterministic.
+                // Sorting by index loc.path and loc.start in sorted files to make the renaming
+                // process deterministic.
                 ids.sort_by_key(|(_, loc)| {
-                    self.ordered_sources.iter().position(|p| p == &loc.path).unwrap()
+                    (self.ordered_sources.iter().position(|p| p == &loc.path).unwrap(), loc.start)
                 });
             }
             for (i, (id, loc)) in ids.iter().enumerate() {


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/11417
for
```Solidity
// SPDX-License-Identifier: MIT
pragma solidity >=0.8.19;
...

function convert(UD60x18 x) pure returns (uint256 result) {
...
}

function convert(uint256 x) pure returns (UD60x18 result) {
...
}
```

we have items as

```
[
  (8378, ItemLocation { path: "lib/prb-math/src/ud60x18/Conversions.sol", start: 462, end: 469 }), 
  (8409, ItemLocation { path: "lib/prb-math/src/ud60x18/Conversions.sol", start: 833, end: 840 })
]
```

but we sort only by path, hence order could be reversed.

Sort also by loc.start to make sure order is preserved