### PR TITLE
chore: use FnMut instead of FnOnce + Copy

### DIFF
--- a/crates/compilers/src/compilers/mod.rs
+++ b/crates/compilers/src/compilers/mod.rs
@@ -75,7 +75,7 @@ pub trait CompilerSettings:
     type Restrictions: CompilerSettingsRestrictions;
 
     /// Executes given fn with mutable reference to configured [OutputSelection].
-    fn update_output_selection(&mut self, f: impl FnOnce(&mut OutputSelection) + Copy);
+    fn update_output_selection(&mut self, f: impl FnMut(&mut OutputSelection));
 
     /// Returns true if artifacts compiled with given `other` config are compatible with this
     /// config and if compilation can be skipped.

--- a/crates/compilers/src/compilers/multi.rs
+++ b/crates/compilers/src/compilers/multi.rs
@@ -204,8 +204,8 @@ impl CompilerSettings for MultiCompilerSettings {
         self.solc.can_use_cached(&other.solc) && self.vyper.can_use_cached(&other.vyper)
     }
 
-    fn update_output_selection(&mut self, f: impl FnOnce(&mut OutputSelection) + Copy) {
-        self.solc.update_output_selection(f);
+    fn update_output_selection(&mut self, mut f: impl FnMut(&mut OutputSelection)) {
+        self.solc.update_output_selection(&mut f);
         self.vyper.update_output_selection(f);
     }
 

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -288,8 +288,8 @@ impl CompilerSettingsRestrictions for SolcRestrictions {
 impl CompilerSettings for SolcSettings {
     type Restrictions = SolcRestrictions;
 
-    fn update_output_selection(&mut self, f: impl FnOnce(&mut OutputSelection) + Copy) {
-        f(&mut self.settings.output_selection)
+    fn update_output_selection(&mut self, mut f: impl FnMut(&mut OutputSelection)) {
+        f(&mut self.settings.output_selection);
     }
 
     fn can_use_cached(&self, other: &Self) -> bool {

--- a/crates/compilers/src/compilers/vyper/settings.rs
+++ b/crates/compilers/src/compilers/vyper/settings.rs
@@ -21,8 +21,8 @@ impl CompilerSettingsRestrictions for VyperRestrictions {
 impl CompilerSettings for VyperSettings {
     type Restrictions = VyperRestrictions;
 
-    fn update_output_selection(&mut self, f: impl FnOnce(&mut OutputSelection)) {
-        f(&mut self.output_selection)
+    fn update_output_selection(&mut self, mut f: impl FnMut(&mut OutputSelection)) {
+        f(&mut self.output_selection);
     }
 
     fn can_use_cached(&self, other: &Self) -> bool {

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -430,10 +430,10 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler> Pro
 
     /// Invokes [CompilerSettings::update_output_selection] on the project's settings and all
     /// additional settings profiles.
-    pub fn update_output_selection(&mut self, f: impl FnOnce(&mut OutputSelection) + Copy) {
-        self.settings.update_output_selection(f);
+    pub fn update_output_selection(&mut self, mut f: impl FnMut(&mut OutputSelection)) {
+        self.settings.update_output_selection(&mut f);
         self.additional_settings.iter_mut().for_each(|(_, s)| {
-            s.update_output_selection(f);
+            s.update_output_selection(&mut f);
         });
     }
 }


### PR DESCRIPTION
FnOnce + Copy doesn't really make sense.