### PR TITLE
fix: make sources' paths absolute

### DIFF
--- a/crates/compilers/src/config.rs
+++ b/crates/compilers/src/config.rs
@@ -616,7 +616,7 @@ impl<L: Language> ProjectPathsConfig<L> {
 
     /// Returns the combined set of `Self::read_sources` + `Self::read_tests` + `Self::read_scripts`
     pub fn read_input_files(&self) -> Result<Sources> {
-        Ok(Source::read_all_files(self.input_files())?)
+        Ok(Source::read_all(self.input_files_iter())?)
     }
 }
 

--- a/crates/compilers/src/flatten.rs
+++ b/crates/compilers/src/flatten.rs
@@ -209,7 +209,7 @@ impl Flattener {
 
         let output = output.compiler_output;
 
-        let sources = Source::read_all_files(vec![target.to_path_buf()])?;
+        let sources = Source::read_all([target.to_path_buf()])?;
         let graph = Graph::<C::Parser>::resolve_sources(&project.paths, sources)?;
 
         let ordered_sources = collect_ordered_deps(target, &project.paths, &graph)?;

--- a/crates/compilers/src/resolver/mod.rs
+++ b/crates/compilers/src/resolver/mod.rs
@@ -400,6 +400,9 @@ impl<P: SourceParser> Graph<P> {
             Ok(())
         }
 
+        // The cache relies on the absolute paths relative to the project root as cache keys.
+        sources.make_absolute(&paths.root);
+
         let mut parser = P::new(paths.with_language_ref());
 
         // we start off by reading all input files, which includes all solidity files from the
@@ -566,14 +569,14 @@ impl<P: SourceParser> Graph<P> {
             let mut versioned_sources = Vec::with_capacity(versioned_nodes.len());
 
             for (version, profile_to_nodes) in versioned_nodes {
-                for (profile_idx, input_node_indixies) in profile_to_nodes {
+                for (profile_idx, input_node_indexes) in profile_to_nodes {
                     let mut sources = Sources::new();
 
                     // all input nodes will be processed
-                    let mut processed_sources = input_node_indixies.iter().copied().collect();
+                    let mut processed_sources = input_node_indexes.iter().copied().collect();
 
                     // we only process input nodes (from sources, tests for example)
-                    for idx in input_node_indixies {
+                    for idx in input_node_indexes {
                         // insert the input node in the sources set and remove it from the available
                         // set
                         let (path, source) =


### PR DESCRIPTION
Cache entries are keyed by absolute path relative to project root, but it's possible to construct and pass in Sources from a relative path, such as CLI argument in `forge lint`/`forge eip712`...

In these cases the path will be relative and will always be a cache miss. This includes the path's imports, which get resolved as relative to the initial path rather than root now with Solar.

Make all paths in Sources absolute when constructing Graph so that this change propagates through the entire compilation process.

I couldn't find a reproducer in today's stable/nightly Foundry, however making `config.solar_project()` use `project()` instead of `ephemeral_project()` will reproduce the behavior explained above.

With this change, `solar_project` will almost never call to solc.