### PR TITLE
perf: parallelize Remapping::get_many

### DIFF
--- a/crates/artifacts/solc/Cargo.toml
+++ b/crates/artifacts/solc/Cargo.toml
@@ -31,9 +31,6 @@ regex.workspace = true
 tokio = { workspace = true, optional = true, features = ["fs"] }
 futures-util = { workspace = true, optional = true }
 
-# walkdir
-walkdir = { workspace = true, optional = true }
-
 # rayon
 rayon = { workspace = true, optional = true }
 
@@ -48,5 +45,5 @@ foundry-compilers-core = { workspace = true, features = ["test-utils"] }
 [features]
 async = ["dep:tokio", "dep:futures-util"]
 checksum = ["foundry-compilers-core/hasher"]
-walkdir = ["dep:walkdir", "foundry-compilers-core/walkdir"]
+walkdir = ["foundry-compilers-core/walkdir"]
 rayon = ["dep:rayon"]

--- a/crates/artifacts/solc/Cargo.toml
+++ b/crates/artifacts/solc/Cargo.toml
@@ -45,5 +45,5 @@ foundry-compilers-core = { workspace = true, features = ["test-utils"] }
 [features]
 async = ["dep:tokio", "dep:futures-util"]
 checksum = ["foundry-compilers-core/hasher"]
-walkdir = ["foundry-compilers-core/walkdir"]
+walkdir = ["rayon", "foundry-compilers-core/walkdir"]
 rayon = ["dep:rayon"]

--- a/crates/artifacts/solc/src/remappings/find.rs
+++ b/crates/artifacts/solc/src/remappings/find.rs
@@ -307,7 +307,7 @@ fn find_remapping_candidates(
 
     // scan all entries in the current dir
     let mut search = Vec::new();
-    for (subdir, file_type, is_symlink) in read_dir(current_dir) {
+    for (subdir, file_type, path_is_symlink) in read_dir(current_dir) {
         // found a solidity file directly the current dir
         if !is_candidate && file_type.is_file() && subdir.extension() == Some("sol".as_ref()) {
             is_candidate = true;
@@ -320,7 +320,7 @@ fn find_remapping_candidates(
             // ├── dep/node_modules
             //     ├── symlink to `my-package`
             // ```
-            if file_type.is_symlink() || is_symlink {
+            if path_is_symlink {
                 if let Ok(target) = utils::canonicalize(&subdir) {
                     if !visited_symlink_dirs.lock().unwrap().insert(target.clone()) {
                         // short-circuiting if we've already visited the symlink


### PR DESCRIPTION
No logic changes except: 2nd commit removes walkdir and doesn't sort by file name anymore because order doesn't matter when we run it in parallel