### PR TITLE
fix(mock): use num_sources in populate for source file count

### DIFF
--- a/crates/compilers/src/project_util/mock.rs
+++ b/crates/compilers/src/project_util/mock.rs
@@ -172,7 +172,7 @@ impl MockProjectGenerator {
 
     /// Adds sources and libraries and populates imports based on the settings
     pub fn populate(&mut self, settings: &MockProjectSettings) -> &mut Self {
-        self.add_sources(settings.num_lib_files);
+        self.add_sources(settings.num_sources);
         for _ in 0..settings.num_libs {
             self.add_lib(settings.num_lib_files);
         }


### PR DESCRIPTION
The MockProjectGenerator::populate method incorrectly used settings.num_lib_files when adding source files, effectively ignoring settings.num_sources. This change aligns the code with the documented intent: num_sources controls the number of source files, while num_lib_files controls the number of files per library. This prevents silent misconfiguration and matches the semantics used elsewhere in the API and tests.