### PR TITLE
chore(`ci`): rescope permissions according to principle of least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -21,6 +20,8 @@ jobs:
     name: test ${{ matrix.rust }} ${{ matrix.flags }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +53,8 @@ jobs:
   doctest:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -67,6 +70,8 @@ jobs:
   feature-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -86,6 +91,8 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -104,6 +111,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -121,6 +130,8 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -133,6 +144,8 @@ jobs:
 
   deny:
     uses: ithacaxyz/ci/.github/workflows/deny.yml@9c8d0dc20e7ad02455d3fdab2378a05f29907630 # main
+    permissions:
+      contents: read
 
   ci-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 name: CodeQL
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -23,6 +22,7 @@ jobs:
     permissions:
       security-events: write
       actions: read
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
By assigning

```
permissions: {}
```

we disable all permissions by default

we then grant it on a per-job basis to exactly what is strictly required