### PR TITLE
perf: improve linking implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ alloy-json-abi = { version = "1.3", features = ["serde_json"] }
 alloy-primitives = { version = "1.3", features = ["serde", "rand"] }
 cfg-if = "1.0"
 dunce = "1.0"
+memchr = "2.7"
 memmap2 = "0.9"
 path-slash = "0.2"
 rayon = "1.11"

--- a/crates/artifacts/solc/Cargo.toml
+++ b/crates/artifacts/solc/Cargo.toml
@@ -19,6 +19,7 @@ foundry-compilers-core.workspace = true
 
 alloy-json-abi.workspace = true
 alloy-primitives.workspace = true
+memchr.workspace = true
 semver.workspace = true
 serde_json.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Collect all references at once, then replace all of them with a simple copy. We can avoid using `string.replace` which creates a copy and is not vectorized because the placeholders are the same length as an address (40 bytes in hex).