### PR TITLE
fix: read runtime sourcemap strings from deployed bytecode

### DIFF
--- a/crates/compilers/src/artifact_output/mod.rs
+++ b/crates/compilers/src/artifact_output/mod.rs
@@ -575,9 +575,9 @@ pub trait Artifact {
 
     /// Returns the runtime bytecode `sourceMap` as str if it was included in the compiler output
     fn get_source_map_deployed_str(&self) -> Option<Cow<'_, str>> {
-        match self.get_bytecode()? {
-            Cow::Borrowed(code) => code.source_map.as_deref().map(Cow::Borrowed),
-            Cow::Owned(code) => code.source_map.map(Cow::Owned),
+        match self.get_deployed_bytecode()? {
+            Cow::Borrowed(code) => code.bytecode.as_ref()?.source_map.as_deref().map(Cow::Borrowed),
+            Cow::Owned(code) => code.bytecode?.source_map.map(Cow::Owned),
         }
     }
 }
@@ -1188,6 +1188,7 @@ impl ArtifactOutput for MinimalCombinedArtifactsHardhatFallback {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn is_artifact() {
@@ -1256,5 +1257,27 @@ mod tests {
     fn test() {
         assert_artifact::<CompactContractBytecode>();
         assert_artifact::<CompactContractBytecodeCow<'static>>();
+    }
+
+    #[test]
+    fn deployed_source_map_string_uses_runtime_bytecode() {
+        let artifact = CompactContractBytecode {
+            abi: None,
+            bytecode: Some(CompactBytecode {
+                object: BytecodeObject::Bytecode(Default::default()),
+                source_map: Some("creation-map".to_string()),
+                link_references: BTreeMap::new(),
+            }),
+            deployed_bytecode: Some(CompactDeployedBytecode {
+                bytecode: Some(CompactBytecode {
+                    object: BytecodeObject::Bytecode(Default::default()),
+                    source_map: Some("runtime-map".to_string()),
+                    link_references: BTreeMap::new(),
+                }),
+                immutable_references: BTreeMap::new(),
+            }),
+        };
+
+        assert_eq!(artifact.get_source_map_deployed_str().as_deref(), Some("runtime-map"));
     }
 }


### PR DESCRIPTION
## Summary

`get_source_map_deployed_str()` currently reads the creation bytecode sourcemap instead of the deployed/runtime bytecode sourcemap.

`get_source_map_deployed()` already uses `get_deployed_bytecode()`, but the string accessor still uses `get_bytecode()`. This makes the two runtime accessors disagree and causes downstream consumers that persist the string sourcemap to store the creation map in the runtime slot.

## Changes

- switch `get_source_map_deployed_str()` to read from `get_deployed_bytecode()`
- add a regression test that gives creation and runtime bytecode different sourcemap strings and asserts the runtime string accessor returns the deployed value

## Why this matters

Downstream tools can use the parsed runtime sourcemap accessor and get the correct result, while the string accessor currently returns the creation sourcemap instead. This is especially visible when consumers persist the raw runtime sourcemap string and later use it for runtime source lookups.

## Testing

- `cargo test -p foundry-compilers deployed_source_map_string_uses_runtime_bytecode`
- `cargo check -p foundry-compilers`
